### PR TITLE
Clamp Gantt bars within timeline viewport

### DIFF
--- a/src/main/java/tech/derbent/app/gannt/view/components/CGanttTimelineBar.java
+++ b/src/main/java/tech/derbent/app/gannt/view/components/CGanttTimelineBar.java
@@ -13,68 +13,76 @@ public class CGanttTimelineBar extends Div {
 
 	private static final long serialVersionUID = 1L;
 
-	public CGanttTimelineBar(final CGanttItem item, final LocalDate timelineStart, final LocalDate timelineEnd, final int totalWidth) {
-		setWidth(totalWidth + "px");
-		setHeight("100%");
-		getStyle().set("display", "flex");
-		getStyle().set("align-items", "center");
-		getStyle().remove("position");
-		getStyle().set("flex-shrink", "0");
-		// getStyle().set("padding-top", "2px");
-		// getStyle().set("padding-bottom", "2px");
-		// getStyle().set("position", "relative");
-		if (!item.hasDates() || (timelineStart == null) || (timelineEnd == null)) {
-			return;
-		}
-		createBar(item, timelineStart, timelineEnd, totalWidth);
-	}
+        public CGanttTimelineBar(final CGanttItem item, final LocalDate timelineStart, final LocalDate timelineEnd, final int totalWidth) {
+                setWidth(totalWidth + "px");
+                setHeight("100%");
+                getStyle().set("display", "flex");
+                getStyle().set("align-items", "center");
+                getStyle().set("position", "relative");
+                getStyle().set("flex-shrink", "0");
+                if (!item.hasDates() || (timelineStart == null) || (timelineEnd == null) || timelineStart.isAfter(timelineEnd)) {
+                        return;
+                }
+                createBar(item, timelineStart, timelineEnd, totalWidth);
+        }
 
-	private void createBar(final CGanttItem item, final LocalDate timelineStart, final LocalDate timelineEnd, final int totalWidth) {
-		final LocalDate itemStart = item.getStartDate();
-		final LocalDate itemEnd = item.getEndDate();
-		final long totalDays = ChronoUnit.DAYS.between(timelineStart, timelineEnd) + 1;
-		if (totalDays <= 0) {
-			return;
-		}
-		final Div bar = new Div();
-		final long startOffset = ChronoUnit.DAYS.between(timelineStart, itemStart);
-		final long itemDuration = ChronoUnit.DAYS.between(itemStart, itemEnd) + 1;
-		final int leftPx = (int) ((startOffset * totalWidth) / (double) totalDays);
-		final int widthPx = (int) ((itemDuration * totalWidth) / (double) totalDays);
-		bar.getStyle().set("position", "absolute");
-		bar.getStyle().set("left", leftPx + "px");
-		bar.getStyle().set("width", widthPx + "px");
-		formatBar(item, bar);
-		final int progress = item.getProgressPercentage();
-		createDisplayText(item, leftPx, progress);
-		// final String displayText = String.format("%s (%s) - %d%%", item.getEntity().getName(), item.getResponsibleName(), progress);
-		// bar.setText(displayText);
-		formatProgress(bar, progress);
-		createToolTip(item, itemStart, itemEnd, bar, progress);
-		add(bar);
-	}
+        private void createBar(final CGanttItem item, final LocalDate timelineStart, final LocalDate timelineEnd, final int totalWidth) {
+                final LocalDate itemStart = item.getStartDate();
+                final LocalDate itemEnd = item.getEndDate();
+                final long totalDays = ChronoUnit.DAYS.between(timelineStart, timelineEnd) + 1;
+                if ((totalDays <= 0) || (itemStart == null) || (itemEnd == null)) {
+                        return;
+                }
+                final LocalDate visibleStart = itemStart.isBefore(timelineStart) ? timelineStart : itemStart;
+                final LocalDate visibleEnd = itemEnd.isAfter(timelineEnd) ? timelineEnd : itemEnd;
+                if (visibleEnd.isBefore(timelineStart) || visibleStart.isAfter(timelineEnd)) {
+                        return;
+                }
+                final Div bar = new Div();
+                final long startOffset = ChronoUnit.DAYS.between(timelineStart, visibleStart);
+                final long visibleDuration = ChronoUnit.DAYS.between(visibleStart, visibleEnd) + 1;
+                final int leftPx = Math.max(0, (int) Math.round((startOffset * totalWidth) / (double) totalDays));
+                int widthPx = (int) Math.round((visibleDuration * totalWidth) / (double) totalDays);
+                widthPx = Math.max(widthPx, 2);
+                if ((leftPx + widthPx) > totalWidth) {
+                        widthPx = Math.max(2, totalWidth - leftPx);
+                }
+                bar.getStyle().set("position", "absolute");
+                bar.getStyle().set("left", leftPx + "px");
+                bar.getStyle().set("width", widthPx + "px");
+                formatBar(item, bar);
+                final int progress = item.getProgressPercentage();
+                createDisplayText(item, leftPx, widthPx, progress, totalWidth);
+                formatProgress(bar, progress);
+                createToolTip(item, visibleStart, visibleEnd, bar, progress);
+                add(bar);
+        }
 
-	private void createDisplayText(final CGanttItem item, final int leftPx, final int progress) {
-		final String displayText = String.format("%s (%s) - %d%%", item.getEntity().getName(), item.getResponsibleName(), progress);
-		final CDiv label = new CDiv(displayText);
-		label.setText(displayText);
-		label.getStyle().set("position", "absolute");
-		label.getStyle().set("left", leftPx + 5 + "px");
-		label.getStyle().set("top", "5");
-		label.getStyle().set("z-index", "1"); // on top of bar
-		label.getStyle().set("background", "transparent");
-		label.getStyle().set("color", "#000"); // or use contrasting color
-		label.getStyle().set("font-size", "12px");
-		label.getStyle().set("white-space", "nowrap");
-		label.setSizeUndefined();
-		add(label);
-	}
+        private void createDisplayText(final CGanttItem item, final int leftPx, final int widthPx, final int progress, final int totalWidth) {
+                final String displayText = String.format("%s (%s) - %d%%", item.getEntity().getName(), item.getResponsibleName(), progress);
+                final CDiv label = new CDiv(displayText);
+                label.setText(displayText);
+                label.getStyle().set("position", "absolute");
+                final int safeLeft = Math.min(leftPx + 5, Math.max(0, totalWidth - widthPx));
+                label.getStyle().set("left", safeLeft + "px");
+                label.getStyle().set("top", "5px");
+                label.getStyle().set("z-index", "1");
+                label.getStyle().set("background", "transparent");
+                label.getStyle().set("color", "#000"); // or use contrasting color
+                label.getStyle().set("font-size", "12px");
+                label.getStyle().set("white-space", "nowrap");
+                label.getStyle().set("max-width", widthPx + "px");
+                label.getStyle().set("overflow", "hidden");
+                label.getStyle().set("text-overflow", "ellipsis");
+                label.setSizeUndefined();
+                add(label);
+        }
 
-	private void createToolTip(final CGanttItem item, final LocalDate itemStart, final LocalDate itemEnd, final Div bar, final int progress) {
-		final String tooltip = String.format("%s\n%s\nProgress: %d%%\nDuration: %d days\nStart: %s\nEnd: %s", item.getEntity().getName(),
-				item.getResponsibleName(), progress, item.getDurationDays(), itemStart, itemEnd);
-		bar.getElement().setAttribute("title", tooltip);
-	}
+        private void createToolTip(final CGanttItem item, final LocalDate itemStart, final LocalDate itemEnd, final Div bar, final int progress) {
+                final String tooltip = String.format("%s\n%s\nProgress: %d%%\nDuration: %d days\nStart: %s\nEnd: %s", item.getEntity().getName(),
+                                item.getResponsibleName(), progress, item.getDurationDays(), itemStart, itemEnd);
+                bar.getElement().setAttribute("title", tooltip);
+        }
 
 	private void formatBar(final CGanttItem item, final Div bar) {
 		bar.getStyle().set("height", "90%");


### PR DESCRIPTION
## Summary
- ensure CGanttTimelineBar positions bars relative to its container and only renders segments that intersect the current timeline window
- keep bar labels, tooltips, and progress overlays inside the visible range so navigation and zoom stay aligned

## Testing
- ./run-all-playwright-tests.sh *(fails: 22 tests in baseline environment)*

------
https://chatgpt.com/codex/tasks/task_e_69038efb22688320a753d4f55f7889a3