### PR TITLE
Fix Gantt grid selection and seed default view

### DIFF
--- a/src/main/java/tech/derbent/api/config/CDataInitializer.java
+++ b/src/main/java/tech/derbent/api/config/CDataInitializer.java
@@ -47,8 +47,8 @@ import tech.derbent.app.decisions.service.CDecisionInitializerService;
 import tech.derbent.app.decisions.service.CDecisionService;
 import tech.derbent.app.decisions.service.CDecisionTypeInitializerService;
 import tech.derbent.app.decisions.service.CDecisionTypeService;
-import tech.derbent.app.gannt.service.CGanntInitializerService;
 import tech.derbent.app.gannt.service.CGanntViewEntityService;
+import tech.derbent.app.gannt.service.CGannttItemInitializerService;
 import tech.derbent.app.meetings.domain.CMeeting;
 import tech.derbent.app.meetings.domain.CMeetingType;
 import tech.derbent.app.meetings.service.CMeetingInitializerService;
@@ -1183,7 +1183,8 @@ public class CDataInitializer {
                                         COrderApprovalInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
                                         CUserProjectSettingsInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
                                         CUserCompanySettingInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
-                                        CGanntInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
+                                        CGannttItemInitializerService.initialize(project, gridEntityService, screenService,
+                                                        pageEntityService, ganntViewEntityService);
                                         CGridInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
                                         CPageEntityInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
 					// Project-specific type and configuration entities

--- a/src/main/java/tech/derbent/app/gannt/domain/CGanttItem.java
+++ b/src/main/java/tech/derbent/app/gannt/domain/CGanttItem.java
@@ -1,6 +1,7 @@
 package tech.derbent.app.gannt.domain;
 
 import java.time.LocalDate;
+import tech.derbent.api.utils.Check;
 import tech.derbent.api.domains.CEntityDB;
 import tech.derbent.api.domains.CProjectItem;
 import tech.derbent.api.utils.CAuxillaries;
@@ -22,27 +23,30 @@ public class CGanttItem extends CEntityDB<CGanttItem> {
 
 	/** Constructor for CGanttItem.
 	 * @param entity The project item to wrap */
-	public CGanttItem(final CProjectItem<?> entity) {
-		this.entity = entity;
-		this.id = 0L;
-		entityType = entity.getClass().getSimpleName();
-		startDate = entity.getStartDate();
-		endDate = entity.getEndDate();
-		parentId = entity.getParentId();
-		parentType = entity.getParentType();
+        public CGanttItem(final CProjectItem<?> entity) {
+                Check.notNull(entity, "Project item cannot be null");
+                this.entity = entity;
+                this.id = entity.getId();
+                entityType = entity.getClass().getSimpleName();
+                startDate = entity.getStartDate();
+                endDate = entity.getEndDate();
+                parentId = entity.getParentId();
+                parentType = entity.getParentType();
 		hierarchyLevel = 0; // Will be calculated by hierarchy service
 	}
 
 	/** Constructor with hierarchy level.
 	 * @param entity         The project item to wrap
 	 * @param hierarchyLevel The level in the hierarchy (0 = top level) */
-	public CGanttItem(final CProjectItem<?> entity, final int hierarchyLevel) {
-		this.entity = entity;
-		entityType = entity.getClass().getSimpleName();
-		startDate = entity.getStartDate();
-		endDate = entity.getEndDate();
-		parentId = entity.getParentId();
-		parentType = entity.getParentType();
+        public CGanttItem(final CProjectItem<?> entity, final int hierarchyLevel) {
+                Check.notNull(entity, "Project item cannot be null");
+                this.entity = entity;
+                this.id = entity.getId();
+                entityType = entity.getClass().getSimpleName();
+                startDate = entity.getStartDate();
+                endDate = entity.getEndDate();
+                parentId = entity.getParentId();
+                parentType = entity.getParentType();
 		this.hierarchyLevel = hierarchyLevel;
 	}
 

--- a/src/main/java/tech/derbent/app/gannt/service/CGannttItemInitializerService.java
+++ b/src/main/java/tech/derbent/app/gannt/service/CGannttItemInitializerService.java
@@ -1,6 +1,48 @@
 package tech.derbent.app.gannt.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tech.derbent.api.screens.service.CDetailSectionService;
+import tech.derbent.api.screens.service.CGridEntityService;
 import tech.derbent.api.screens.service.CInitializerServiceBase;
+import tech.derbent.api.utils.Check;
+import tech.derbent.app.gannt.domain.CGanntViewEntity;
+import tech.derbent.app.page.service.CPageEntityService;
+import tech.derbent.app.projects.domain.CProject;
 
-public class CGannttItemInitializerService extends CInitializerServiceBase {
+/** CGannttItemInitializerService - Wraps Gantt initializer logic and seeds a default project timeline view. */
+public final class CGannttItemInitializerService extends CInitializerServiceBase {
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(CGannttItemInitializerService.class);
+        private static final String DEFAULT_VIEW_DESCRIPTION =
+                        "Automatically generated Gantt timeline that combines activities and meetings.";
+        private static final String DEFAULT_VIEW_NAME = "Project Timeline";
+
+        private CGannttItemInitializerService() {}
+
+        public static void initialize(final CProject project, final CGridEntityService gridEntityService,
+                        final CDetailSectionService detailSectionService, final CPageEntityService pageEntityService,
+                        final CGanntViewEntityService ganntViewEntityService) throws Exception {
+                Check.notNull(project, "project cannot be null");
+                Check.notNull(gridEntityService, "gridEntityService cannot be null");
+                Check.notNull(detailSectionService, "detailSectionService cannot be null");
+                Check.notNull(pageEntityService, "pageEntityService cannot be null");
+                Check.notNull(ganntViewEntityService, "ganntViewEntityService cannot be null");
+                LOGGER.debug("Initializing Gantt metadata and default view for project: {}", project.getName());
+                CGanntInitializerService.initialize(project, gridEntityService, detailSectionService, pageEntityService);
+                ensureDefaultView(project, ganntViewEntityService);
+        }
+
+        private static void ensureDefaultView(final CProject project, final CGanntViewEntityService ganntViewEntityService) {
+                ganntViewEntityService.findByNameAndProject(DEFAULT_VIEW_NAME, project).ifPresentOrElse(existing -> {
+                        LOGGER.debug("Default Gantt view already exists for project {} with id {}", project.getName(),
+                                        existing.getId());
+                }, () -> {
+                        LOGGER.info("Creating default Gantt view '{}' for project {}", DEFAULT_VIEW_NAME, project.getName());
+                        final CGanntViewEntity view = ganntViewEntityService.newEntity(DEFAULT_VIEW_NAME, project);
+                        view.setDescription(DEFAULT_VIEW_DESCRIPTION);
+                        view.setActive(true);
+                        ganntViewEntityService.save(view);
+                });
+        }
 }

--- a/src/main/java/tech/derbent/app/gannt/view/CMasterViewSectionGannt.java
+++ b/src/main/java/tech/derbent/app/gannt/view/CMasterViewSectionGannt.java
@@ -111,6 +111,7 @@ public class CMasterViewSectionGannt<EntityClass extends CEntityDB<EntityClass>>
 			grid = new CGanntGrid(currentProject, activityService, meetingService, pageEntityService);
 			grid.asSingleSelect().addValueChangeListener(this::onSelectionChange);
 			add(grid);
+			grid.refresh();
 			// add(CSOGanntChart.createGanttChart());
 		} catch (final Exception e) {
 			LOGGER.error("Error creating Gantt grid for project: {}", e.getMessage());

--- a/src/main/java/tech/derbent/app/gannt/view/components/CGanntGrid.java
+++ b/src/main/java/tech/derbent/app/gannt/view/components/CGanntGrid.java
@@ -38,9 +38,11 @@ public class CGanntGrid extends CGrid<CGanttItem> {
 		dataProvider = new CGanttDataProvider(project, activityService, meetingService);
 		addThemeVariants(GridVariant.LUMO_NO_BORDER, GridVariant.LUMO_ROW_STRIPES, GridVariant.LUMO_COMPACT);
 		setHeightFull();
-		setDataProvider(dataProvider);
-		createColumns();
-	}
+                setDataProvider(dataProvider);
+                asSingleSelect().setDeselectAllowed(false);
+                createColumns();
+                ensureSelectionWhenDataAvailable();
+        }
 
 	/** Calculate the overall timeline range from all items to properly scale the bars. */
 	private void calculateTimelineRange() {
@@ -105,9 +107,11 @@ public class CGanntGrid extends CGrid<CGanttItem> {
 	}
 
 	/** Public refresh hook. */
-	public void refresh() {
-		dataProvider.refreshAll();
-	}
+        public void refresh() {
+                dataProvider.refreshAll();
+                getDataCommunicator().reset();
+                ensureSelectionWhenDataAvailable();
+        }
 
 	/** Set the timeline column width and refresh the view.
 	 * @param widthPixels The new width in pixels */


### PR DESCRIPTION
## Summary
- ensure CGanttItem rows map back to their underlying entity ids so single-selection remains stable
- refresh CGanntGrid and its master section to keep one selection and reset the data communicator when the timeline updates
- wrap the gantt initializer in a CGannttItemInitializerService that also seeds a default "Project Timeline" view and invoke it from the data bootstrapper

## Testing
- ./run-all-playwright-tests.sh *(fails: maven cannot resolve org.springframework.boot:spring-boot-starter-parent:3.5.0 because https://maven.vaadin.com/vaadin-addons responds 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69106da6fc2483208f37d6dfd682acee)