### PR TITLE
Add kanban column management and ordering support

### DIFF
--- a/src/main/java/tech/derbent/app/kanban/kanbanline/domain/CKanbanColumn.java
+++ b/src/main/java/tech/derbent/app/kanban/kanbanline/domain/CKanbanColumn.java
@@ -9,11 +9,24 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import tech.derbent.api.annotations.AMetaData;
 import tech.derbent.api.entity.domain.CEntityNamed;
+import tech.derbent.api.screens.service.IOrderedEntity;
 
 @Entity
 @Table (name = "ckanbancolumn")
 @AttributeOverride (name = "id", column = @Column (name = "kanban_column_id"))
-public class CKanbanColumn extends CEntityNamed<CKanbanColumn> {
+public class CKanbanColumn extends CEntityNamed<CKanbanColumn> implements IOrderedEntity {
+
+	public static final String DEFAULT_COLOR = "#FFD54F";
+	public static final String DEFAULT_ICON = "vaadin:columns";
+	public static final String ENTITY_TITLE_PLURAL = "Kanban Columns";
+	public static final String ENTITY_TITLE_SINGULAR = "Kanban Column";
+
+	@Column (name = "item_order", nullable = false)
+	@AMetaData (
+			displayName = "Order", required = false, readOnly = true, defaultValue = "1", description = "Sort order for kanban columns",
+			hidden = false
+	)
+	private Integer itemOrder = 1;
 
 	@ManyToOne (fetch = FetchType.LAZY)
 	@JoinColumn (name = "kanban_line_id", nullable = false)
@@ -32,7 +45,13 @@ public class CKanbanColumn extends CEntityNamed<CKanbanColumn> {
 		setKanbanLine(kanbanLine);
 	}
 
+	@Override
+	public Integer getItemOrder() { return itemOrder; }
+
 	public CKanbanLine getKanbanLine() { return kanbanLine; }
+
+	@Override
+	public void setItemOrder(final Integer itemOrder) { this.itemOrder = itemOrder; }
 
 	public void setKanbanLine(final CKanbanLine kanbanLine) {
 		if (kanbanLine == null) {

--- a/src/main/java/tech/derbent/app/kanban/kanbanline/service/CKanbanColumnService.java
+++ b/src/main/java/tech/derbent/app/kanban/kanbanline/service/CKanbanColumnService.java
@@ -1,0 +1,130 @@
+package tech.derbent.app.kanban.kanbanline.service;
+
+import java.time.Clock;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tech.derbent.api.entity.service.CAbstractService;
+import tech.derbent.api.registry.IEntityRegistrable;
+import tech.derbent.api.screens.service.IOrderedEntityService;
+import tech.derbent.api.utils.Check;
+import tech.derbent.app.kanban.kanbanline.domain.CKanbanColumn;
+import tech.derbent.app.kanban.kanbanline.domain.CKanbanLine;
+import tech.derbent.base.session.service.ISessionService;
+
+@Service
+@PreAuthorize ("isAuthenticated()")
+public class CKanbanColumnService extends CAbstractService<CKanbanColumn>
+		implements IEntityRegistrable, IOrderedEntityService<CKanbanColumn> {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CKanbanColumnService.class);
+
+	public CKanbanColumnService(final IKanbanColumnRepository repository, final Clock clock, final ISessionService sessionService) {
+		super(repository, clock, sessionService);
+	}
+
+	@Override
+	public Class<CKanbanColumn> getEntityClass() { return CKanbanColumn.class; }
+
+	@Override
+	public Class<?> getInitializerServiceClass() { return null; }
+
+	@Override
+	public Class<?> getPageServiceClass() { return null; }
+
+	@Override
+	public Class<?> getServiceClass() { return this.getClass(); }
+
+	public List<CKanbanColumn> findByMaster(final CKanbanLine master) {
+		Check.notNull(master, "Master kanban line cannot be null");
+		if (master.getId() == null) {
+			return List.of();
+		}
+		return getTypedRepository().findByMaster(master);
+	}
+
+	public Integer getNextItemOrder(final CKanbanLine master) {
+		Check.notNull(master, "Master kanban line cannot be null");
+		if (master.getId() == null) {
+			return 1;
+		}
+		return getTypedRepository().getNextItemOrder(master);
+	}
+
+	private IKanbanColumnRepository getTypedRepository() { return (IKanbanColumnRepository) repository; }
+
+	@Override
+	public void initializeNewEntity(final CKanbanColumn entity) {
+		super.initializeNewEntity(entity);
+		Check.notNull(entity, "Kanban column cannot be null");
+		if (entity.getName() == null || entity.getName().isBlank()) {
+			entity.setName("Column");
+		}
+	}
+
+	@Override
+	@Transactional
+	public void moveItemDown(final CKanbanColumn childItem) {
+		Check.notNull(childItem, "Kanban column cannot be null");
+		final CKanbanLine master = childItem.getKanbanLine();
+		Check.notNull(master, "Kanban line cannot be null for column");
+		final List<CKanbanColumn> items = findByMaster(master);
+		for (int i = 0; i < items.size(); i++) {
+			if (items.get(i).getId().equals(childItem.getId()) && (i < (items.size() - 1))) {
+				final CKanbanColumn nextColumn = items.get(i + 1);
+				final Integer currentOrder = childItem.getItemOrder();
+				final Integer nextOrder = nextColumn.getItemOrder();
+				childItem.setItemOrder(nextOrder);
+				nextColumn.setItemOrder(currentOrder);
+				save(childItem);
+				save(nextColumn);
+				break;
+			}
+		}
+	}
+
+	@Override
+	@Transactional
+	public void moveItemUp(final CKanbanColumn childItem) {
+		Check.notNull(childItem, "Kanban column cannot be null");
+		final CKanbanLine master = childItem.getKanbanLine();
+		Check.notNull(master, "Kanban line cannot be null for column");
+		final List<CKanbanColumn> items = findByMaster(master);
+		for (int i = 0; i < items.size(); i++) {
+			if (items.get(i).getId().equals(childItem.getId()) && (i > 0)) {
+				final CKanbanColumn previousColumn = items.get(i - 1);
+				final Integer currentOrder = childItem.getItemOrder();
+				final Integer previousOrder = previousColumn.getItemOrder();
+				childItem.setItemOrder(previousOrder);
+				previousColumn.setItemOrder(currentOrder);
+				save(childItem);
+				save(previousColumn);
+				break;
+			}
+		}
+	}
+
+	@Override
+	@Transactional
+	public CKanbanColumn save(final CKanbanColumn entity) {
+		Check.notNull(entity, "Kanban column cannot be null");
+		if (entity.getItemOrder() == null || entity.getItemOrder() <= 0) {
+			entity.setItemOrder(getNextItemOrder(entity.getKanbanLine()));
+		}
+		return super.save(entity);
+	}
+
+	@Override
+	@Transactional
+	public void delete(final CKanbanColumn entity) {
+		Check.notNull(entity, "Kanban column cannot be null");
+		LOGGER.debug("Deleting kanban column: {}", entity.getId());
+		if (entity.getKanbanLine() != null) {
+			entity.getKanbanLine().removeKanbanColumn(entity);
+		}
+		super.delete(entity);
+	}
+}

--- a/src/main/java/tech/derbent/app/kanban/kanbanline/service/CKanbanLineInitializerService.java
+++ b/src/main/java/tech/derbent/app/kanban/kanbanline/service/CKanbanLineInitializerService.java
@@ -13,7 +13,9 @@ import tech.derbent.api.screens.service.CDetailSectionService;
 import tech.derbent.api.screens.service.CGridEntityService;
 import tech.derbent.api.screens.service.CInitializerServiceBase;
 import tech.derbent.api.screens.service.CInitializerServiceNamedEntity;
+import tech.derbent.api.utils.Check;
 import tech.derbent.app.companies.domain.CCompany;
+import tech.derbent.app.kanban.kanbanline.domain.CKanbanColumn;
 import tech.derbent.app.kanban.kanbanline.domain.CKanbanLine;
 import tech.derbent.app.page.service.CPageEntityService;
 import tech.derbent.app.projects.domain.CProject;
@@ -32,7 +34,7 @@ public class CKanbanLineInitializerService extends CInitializerServiceBase {
 			final CDetailSection detailSection = createBaseScreenEntity(project, clazz);
 			CInitializerServiceNamedEntity.createBasicView(detailSection, clazz, project, true);
 			detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(clazz, "company"));
-			detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(clazz, "columns"));
+			detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(clazz, "kanbanColumns"));
 			detailSection.addScreenLine(CDetailLinesService.createSection("Audit"));
 			detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(clazz, "createdDate"));
 			detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(clazz, "lastModifiedDate"));
@@ -67,6 +69,19 @@ public class CKanbanLineInitializerService extends CInitializerServiceBase {
 				}
 		};
 		initializeCompanyEntity(sampleLines, (CEntityOfCompanyService<?>) CSpringContext.getBean(CEntityRegistry.getServiceClassForEntity(clazz)),
-				company, minimal, null);
+				company, minimal, (entity, index) -> {
+					Check.instanceOf(entity, CKanbanLine.class, "Expected Kanban line for column initialization");
+					final CKanbanLine line = (CKanbanLine) entity;
+					if (index == 0) {
+						line.addKanbanColumn(new CKanbanColumn("Backlog", line));
+						line.addKanbanColumn(new CKanbanColumn("In Progress", line));
+						line.addKanbanColumn(new CKanbanColumn("Done", line));
+					} else {
+						line.addKanbanColumn(new CKanbanColumn("To Do", line));
+						line.addKanbanColumn(new CKanbanColumn("Doing", line));
+						line.addKanbanColumn(new CKanbanColumn("Review", line));
+						line.addKanbanColumn(new CKanbanColumn("Done", line));
+					}
+				});
 	}
 }

--- a/src/main/java/tech/derbent/app/kanban/kanbanline/service/CKanbanLineService.java
+++ b/src/main/java/tech/derbent/app/kanban/kanbanline/service/CKanbanLineService.java
@@ -42,7 +42,7 @@ public class CKanbanLineService extends CEntityOfCompanyService<CKanbanLine> imp
 		LOGGER.debug("Initializing new Kanban line");
 		setNameOfEntity(entity, "Kanban Line");
 		if (entity.getKanbanColumns() == null) {
-			entity.setKanbanColumns(new java.util.ArrayList<>());
+			entity.setKanbanColumns(new java.util.LinkedHashSet<>());
 		}
 	}
 }

--- a/src/main/java/tech/derbent/app/kanban/kanbanline/service/CPageServiceKanbanLine.java
+++ b/src/main/java/tech/derbent/app/kanban/kanbanline/service/CPageServiceKanbanLine.java
@@ -2,18 +2,35 @@ package tech.derbent.app.kanban.kanbanline.service;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tech.derbent.api.config.CSpringContext;
 import tech.derbent.api.services.pageservice.CPageServiceDynamicPage;
 import tech.derbent.api.services.pageservice.IPageServiceImplementer;
 import tech.derbent.api.utils.Check;
 import tech.derbent.app.kanban.kanbanline.domain.CKanbanLine;
+import tech.derbent.app.kanban.kanbanline.view.CComponentListKanbanColumns;
 
 public class CPageServiceKanbanLine extends CPageServiceDynamicPage<CKanbanLine> {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(CPageServiceKanbanLine.class);
 	private static final long serialVersionUID = 1L;
+	private CComponentListKanbanColumns componentKanbanColumns;
+	private CKanbanColumnService kanbanColumnService;
 
 	public CPageServiceKanbanLine(final IPageServiceImplementer<CKanbanLine> view) {
 		super(view);
+		try {
+			kanbanColumnService = CSpringContext.getBean(CKanbanColumnService.class);
+		} catch (final Exception e) {
+			LOGGER.error("Failed to initialize CKanbanColumnService", e);
+		}
+	}
+
+	public CComponentListKanbanColumns createKanbanColumnsComponent() {
+		if (componentKanbanColumns == null) {
+			componentKanbanColumns = new CComponentListKanbanColumns(kanbanColumnService);
+			componentKanbanColumns.registerWithPageService(this);
+		}
+		return componentKanbanColumns;
 	}
 
 	@Override

--- a/src/main/java/tech/derbent/app/kanban/kanbanline/service/IKanbanColumnRepository.java
+++ b/src/main/java/tech/derbent/app/kanban/kanbanline/service/IKanbanColumnRepository.java
@@ -1,0 +1,25 @@
+package tech.derbent.app.kanban.kanbanline.service;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import tech.derbent.api.entity.service.IAbstractRepository;
+import tech.derbent.app.kanban.kanbanline.domain.CKanbanColumn;
+import tech.derbent.app.kanban.kanbanline.domain.CKanbanLine;
+
+/** IKanbanColumnRepository - Repository interface for CKanbanColumn entity.
+ * Provides database access for Kanban column definitions within a kanban line. */
+public interface IKanbanColumnRepository extends IAbstractRepository<CKanbanColumn> {
+
+	/** Find all columns for a kanban line, ordered by itemOrder.
+	 * @param master the kanban line
+	 * @return list of columns ordered by itemOrder ascending */
+	@Query ("SELECT e FROM #{#entityName} e LEFT JOIN FETCH e.kanbanLine WHERE e.kanbanLine = :master ORDER BY e.itemOrder ASC")
+	List<CKanbanColumn> findByMaster(@Param ("master") CKanbanLine master);
+
+	/** Get the next item order number for new columns in a kanban line.
+	 * @param master the kanban line
+	 * @return the next available order number */
+	@Query ("SELECT COALESCE(MAX(e.itemOrder), 0) + 1 FROM #{#entityName} e WHERE e.kanbanLine = :master")
+	Integer getNextItemOrder(@Param ("master") CKanbanLine master);
+}

--- a/src/main/java/tech/derbent/app/kanban/kanbanline/view/CComponentListKanbanColumns.java
+++ b/src/main/java/tech/derbent/app/kanban/kanbanline/view/CComponentListKanbanColumns.java
@@ -1,0 +1,90 @@
+package tech.derbent.app.kanban.kanbanline.view;
+
+import java.util.List;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tech.derbent.api.grid.domain.CGrid;
+import tech.derbent.api.interfaces.drag.CEvent;
+import tech.derbent.api.ui.component.enhanced.CComponentListEntityBase;
+import tech.derbent.api.utils.Check;
+import tech.derbent.app.kanban.kanbanline.domain.CKanbanColumn;
+import tech.derbent.app.kanban.kanbanline.domain.CKanbanLine;
+import tech.derbent.app.kanban.kanbanline.service.CKanbanColumnService;
+
+/** CComponentListKanbanColumns - Component for managing CKanbanColumn entities within a CKanbanLine. Provides CRUD and ordering controls for
+ * kanban column definitions. */
+public class CComponentListKanbanColumns extends CComponentListEntityBase<CKanbanLine, CKanbanColumn> {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CComponentListKanbanColumns.class);
+	private static final long serialVersionUID = 1L;
+
+	public CComponentListKanbanColumns(final CKanbanColumnService kanbanColumnService) {
+		super("Kanban Columns", CKanbanLine.class, CKanbanColumn.class, kanbanColumnService);
+		Check.notNull(kanbanColumnService, "KanbanColumnService cannot be null");
+		setDynamicHeight("400px");
+	}
+
+	@Override
+	public void configureGrid(final CGrid<CKanbanColumn> grid) {
+		Check.notNull(grid, "Grid cannot be null");
+		grid.addIdColumn(CKanbanColumn::getId, "ID", "id");
+		grid.addIntegerColumn(CKanbanColumn::getItemOrder, "Order", "itemOrder");
+		grid.addShortTextColumn(CKanbanColumn::getName, "Name", "name");
+		grid.addShortTextColumn(CKanbanColumn::getDescription, "Description", "description");
+		grid.addBooleanColumn(CKanbanColumn::getActive, "Status", "Active", "Inactive");
+	}
+
+	@Override
+	public void drag_checkEventAfterPass(final CEvent event) {
+		// No-op for kanban column list (no special drag behavior).
+	}
+
+	@Override
+	public void drag_checkEventBeforePass(final CEvent event) {
+		// No-op for kanban column list (no special drag behavior).
+	}
+
+	@Override
+	protected CKanbanColumn createNewEntity() {
+		Check.notNull(getMasterEntity(), "Kanban line must be selected before creating columns");
+		final CKanbanColumn column = new CKanbanColumn("New Column", getMasterEntity());
+		column.setItemOrder(getNextOrder());
+		return column;
+	}
+
+	@Override
+	protected Integer getNextOrder() {
+		Check.notNull(getMasterEntity(), "Kanban line cannot be null when calculating next order");
+		if (getMasterEntity().getId() == null) {
+			return 1;
+		}
+		final CKanbanColumnService service = (CKanbanColumnService) childService;
+		return service.getNextItemOrder(getMasterEntity());
+	}
+
+	@Override
+	protected List<CKanbanColumn> loadItems(final CKanbanLine master) {
+		Check.notNull(master, "Kanban line cannot be null");
+		if (master.getId() == null) {
+			LOGGER.debug("Kanban line is new, returning empty columns list");
+			return List.of();
+		}
+		final CKanbanColumnService service = (CKanbanColumnService) childService;
+		return service.findByMaster(master);
+	}
+
+	@Override
+	protected void openEditDialog(final CKanbanColumn entity, final Consumer<CKanbanColumn> saveCallback, final boolean isNew) {
+		try {
+			final CDialogKanbanColumnEdit dialog = new CDialogKanbanColumnEdit(entity, saveCallback, isNew);
+			dialog.open();
+		} catch (final Exception e) {
+			LOGGER.error("Error opening kanban column edit dialog", e);
+			throw new IllegalStateException("Unable to open kanban column dialog", e);
+		}
+	}
+
+	@Override
+	public String getComponentName() { return "kanbanColumns"; }
+}

--- a/src/main/java/tech/derbent/app/kanban/kanbanline/view/CDialogKanbanColumnEdit.java
+++ b/src/main/java/tech/derbent/app/kanban/kanbanline/view/CDialogKanbanColumnEdit.java
@@ -1,0 +1,73 @@
+package tech.derbent.app.kanban.kanbanline.view;
+
+import java.util.List;
+import java.util.function.Consumer;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import tech.derbent.api.annotations.CFormBuilder;
+import tech.derbent.api.components.CBinderFactory;
+import tech.derbent.api.components.CEnhancedBinder;
+import tech.derbent.api.ui.dialogs.CDialogDBEdit;
+import tech.derbent.api.utils.Check;
+import tech.derbent.app.kanban.kanbanline.domain.CKanbanColumn;
+
+public class CDialogKanbanColumnEdit extends CDialogDBEdit<CKanbanColumn> {
+
+	private static final long serialVersionUID = 1L;
+	private final CEnhancedBinder<CKanbanColumn> binder;
+	private final CFormBuilder<CKanbanColumn> formBuilder;
+
+	public CDialogKanbanColumnEdit(final CKanbanColumn entity, final Consumer<CKanbanColumn> onSave, final boolean isNew) throws Exception {
+		super(entity, onSave, isNew);
+		binder = CBinderFactory.createEnhancedBinder(CKanbanColumn.class);
+		formBuilder = new CFormBuilder<>();
+		setupDialog();
+		populateForm();
+	}
+
+	private void createFormFields() throws Exception {
+		Check.notNull(getDialogLayout(), "Dialog layout must be initialized before building form fields");
+		getDialogLayout().add(formBuilder.build(CKanbanColumn.class, binder, List.of("name", "description", "itemOrder", "active")));
+	}
+
+	@Override
+	public String getDialogTitleString() { return getFormTitleString(); }
+
+	@Override
+	protected Icon getFormIcon() { return VaadinIcon.TABLE.create(); }
+
+	@Override
+	protected String getFormTitleString() { return isNew ? "Add Kanban Column" : "Edit Kanban Column"; }
+
+	@Override
+	protected String getSuccessCreateMessage() { return "Kanban column created successfully"; }
+
+	@Override
+	protected String getSuccessUpdateMessage() { return "Kanban column updated successfully"; }
+
+	@Override
+	protected void populateForm() {
+		if (getEntity() != null) {
+			binder.readBean(getEntity());
+		}
+	}
+
+	@Override
+	protected void setupContent() throws Exception {
+		super.setupContent();
+		setWidth("500px");
+		setHeight("450px");
+		setResizable(true);
+		createFormFields();
+	}
+
+	@Override
+	protected void validateForm() {
+		Check.notNull(getEntity(), "Kanban column cannot be null when validating");
+		try {
+			binder.writeBean(getEntity());
+		} catch (final Exception e) {
+			throw new IllegalStateException("Failed to validate kanban column", e);
+		}
+	}
+}


### PR DESCRIPTION
### Motivation
- Kanban lines must own an ordered, editable set of column definitions that can be added, removed, edited and re-sorted via the UI.
- Existing OneToMany / ordered-child patterns (DetailLines / SprintItems) provide a reusable interaction model and ordering service contracts.
- Columns are always owned by their Kanban line and must be deleted when removed (no global column selection list). 
- Provide a visual component that follows existing `CComponentListEntityBase` patterns so page services can auto-register and bind it.

### Description
- Introduced ordered Kanban column domain metadata by making `CKanbanColumn` implement `IOrderedEntity` and adding `itemOrder` plus entity constants (`DEFAULT_ICON`, `DEFAULT_COLOR`, titles).
- Converted `CKanbanLine.kanbanColumns` to a `Set` with `@OrderBy("itemOrder ASC")`, added `getNextKanbanColumnOrder()` and updated add/remove/set behavior to maintain ordering and owner link.
- Added persistence/service/view support: `IKanbanColumnRepository`, `CKanbanColumnService` (ordering move/save/delete logic), `CDialogKanbanColumnEdit` (edit dialog), and `CComponentListKanbanColumns` (list + reorder UI component) wired into `CPageServiceKanbanLine` via `createKanbanColumnsComponent()`.
- Updated initializer and page wiring: `CKanbanLineInitializerService` seeds sample columns, `CKanbanLineService` initialization ensures collection type, and form metadata (`createComponentMethod`) points to the new component name `kanbanColumns`.

### Testing
- Ran the menu UI automation via `./run-playwright-tests.sh menu` which invokes the Maven build and tests as part of the Playwright script. 
- The project compiled during the test run after fixing earlier compile issues introduced during development. 
- The automated test run executed unit and integration tests, but the Playwright menu navigation test failed due to browser environment missing (Playwright reported no Chromium and tests hit a null `page`), causing the suite to fail. 
- A prior attempt to run `./run-playwright-tests.sh all` failed because `all` is not a valid option for the script (help/usage printed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946d65eb0888320a176d33fad04b2ef)