### PR TITLE
Add modal progress dialog and use it for asynchronous DB reset flows

### DIFF
--- a/src/main/java/tech/derbent/api/ui/dialogs/CDialogConfirmation.java
+++ b/src/main/java/tech/derbent/api/ui/dialogs/CDialogConfirmation.java
@@ -27,10 +27,10 @@ public final class CDialogConfirmation extends CDialogInfoBase {
 	@Override
 	protected void setupButtons() {
 		final CButton yesButton = CButton.createPrimary("Yes", null, e -> {
+			close();
 			if (onConfirm != null) {
 				onConfirm.run();
 			}
-			close();
 		});
 		yesButton.setAutofocus(false);
 		final CButton noButton = CButton.createTertiary("No", null, e -> close());

--- a/src/main/java/tech/derbent/api/ui/dialogs/CDialogProgress.java
+++ b/src/main/java/tech/derbent/api/ui/dialogs/CDialogProgress.java
@@ -1,0 +1,57 @@
+package tech.derbent.api.ui.dialogs;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.progressbar.ProgressBar;
+import tech.derbent.api.utils.Check;
+
+/** CDialogProgress - Dialog for displaying a modal progress indicator without actions. Layer: View (MVC) Used for long-running operations where the
+ * user should wait until completion. */
+public final class CDialogProgress extends CDialog {
+
+	private static final long serialVersionUID = 1L;
+	private final String message;
+	private final String title;
+
+	public CDialogProgress(final String title, final String message) {
+		super();
+		Check.notBlank(title, "Progress dialog title cannot be blank");
+		Check.notBlank(message, "Progress dialog message cannot be blank");
+		this.title = title;
+		this.message = message;
+		try {
+			setupDialog();
+			setCloseOnEsc(false);
+			setCloseOnOutsideClick(false);
+		} catch (final Exception e) {
+			LOGGER.error("Error setting up progress dialog", e);
+		}
+	}
+
+	@Override
+	public String getDialogTitleString() { return title; }
+
+	@Override
+	protected Icon getFormIcon() { return VaadinIcon.SPINNER.create(); }
+
+	@Override
+	protected String getFormTitleString() { return title; }
+
+	@Override
+	protected void setupButtons() {
+		// No buttons for progress dialog.
+	}
+
+	@Override
+	protected void setupContent() {
+		final Div messageDiv = new Div();
+		messageDiv.setText(message);
+		messageDiv.getStyle().set("text-align", "center");
+		messageDiv.getStyle().set("margin", "16px 0");
+		final ProgressBar progressBar = new ProgressBar();
+		progressBar.setIndeterminate(true);
+		progressBar.setWidthFull();
+		mainLayout.add(messageDiv, progressBar);
+	}
+}

--- a/src/main/java/tech/derbent/api/ui/notifications/CNotificationService.java
+++ b/src/main/java/tech/derbent/api/ui/notifications/CNotificationService.java
@@ -9,6 +9,7 @@ import tech.derbent.api.ui.dialogs.CDialogConfirmation;
 import tech.derbent.api.ui.dialogs.CDialogException;
 import tech.derbent.api.ui.dialogs.CDialogInformation;
 import tech.derbent.api.ui.dialogs.CDialogMessageWithDetails;
+import tech.derbent.api.ui.dialogs.CDialogProgress;
 import tech.derbent.api.ui.dialogs.CDialogWarning;
 import tech.derbent.api.utils.Check;
 
@@ -172,5 +173,14 @@ public class CNotificationService {
 		LOGGER.debug("Showing warning dialog: {}", message);
 		final CDialogWarning dialog = new CDialogWarning(message);
 		dialog.open();
+	}
+
+	public static CDialogProgress showProgressDialog(final String title, final String message) {
+		Check.notBlank(title, "Progress dialog title cannot be empty");
+		Check.notBlank(message, "Progress dialog message cannot be empty");
+		LOGGER.debug("Showing progress dialog: {}", title);
+		final CDialogProgress dialog = new CDialogProgress(title, message);
+		dialog.open();
+		return dialog;
 	}
 }


### PR DESCRIPTION
### Motivation

- Database reset is a long-running operation that freezes the UI while running synchronously, so users need a visual progress indicator.
- Confirmation dialogs should be closed before starting the long task to avoid blocking the UI thread.
- The progress UI should be reusable across the application for other long-running, non-cancellable tasks.

### Description

- Add `CDialogProgress` — a modal, non-cancellable progress dialog component with an indeterminate `ProgressBar` and message text.
- Expose `showProgressDialog(...)` from `CNotificationService` which creates and opens `CDialogProgress` and returns the dialog instance.
- Update `CDialogConfirmation` to close the confirmation dialog before running the `onConfirm` action to avoid UI blocking.
- Replace synchronous DB-reset logic in `CCustomLoginView` and `CSystemSettingsView` with `runDatabaseReset(...)` that runs `CDataInitializer.reloadForced(...)` on a background thread, shows the progress dialog, and uses `UI.access(...)` to close the dialog and show notifications on completion or error.

### Testing

- Ran `./run-playwright-tests.sh all`, which reported an invalid option and was not executed successfully.
- Ran `./run-playwright-tests.sh menu`, which attempted to run but the Playwright browser was not available so the UI test failed (test harness reported `page` was null).
- The project compiled and tests started under Maven as part of the Playwright-run sequence; the UI test `CMenuNavigationTest` failed due to the missing browser environment.
- No new unit tests were added for the dialog; manual/Playwright UI verification is required in an environment with browsers installed to confirm end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947134fdf1883208decc20c6c3393be)