### PR TITLE
Add status selection to Kanban columns

### DIFF
--- a/src/main/java/tech/derbent/app/kanban/kanbanline/domain/CKanbanColumn.java
+++ b/src/main/java/tech/derbent/app/kanban/kanbanline/domain/CKanbanColumn.java
@@ -2,13 +2,18 @@ package tech.derbent.app.kanban.kanbanline.domain;
 
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
+import java.util.ArrayList;
+import java.util.List;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import tech.derbent.api.annotations.AMetaData;
 import tech.derbent.api.entity.domain.CEntityNamed;
+import tech.derbent.api.entityOfCompany.domain.CProjectItemStatus;
 import tech.derbent.api.screens.service.IOrderedEntity;
 
 @Entity
@@ -35,6 +40,17 @@ public class CKanbanColumn extends CEntityNamed<CKanbanColumn> implements IOrder
 	)
 	private CKanbanLine kanbanLine;
 
+	@ManyToMany (fetch = FetchType.EAGER)
+	@JoinTable (
+			name = "ckanbancolumn_statuses", joinColumns = @JoinColumn (name = "kanban_column_id"),
+			inverseJoinColumns = @JoinColumn (name = "cprojectitemstatus_id")
+	)
+	@AMetaData (
+			displayName = "Statuses", required = false, readOnly = false, description = "Company statuses included in this column", hidden = false,
+			setBackgroundFromColor = true, useIcon = true, dataProviderBean = "CProjectItemStatusService", useGridSelection = true
+	)
+	private List<CProjectItemStatus> statuses = new ArrayList<>();
+
 	/** Default constructor for JPA. */
 	public CKanbanColumn() {
 		super();
@@ -50,6 +66,8 @@ public class CKanbanColumn extends CEntityNamed<CKanbanColumn> implements IOrder
 
 	public CKanbanLine getKanbanLine() { return kanbanLine; }
 
+	public List<CProjectItemStatus> getStatuses() { return statuses; }
+
 	@Override
 	public void setItemOrder(final Integer itemOrder) { this.itemOrder = itemOrder; }
 
@@ -59,5 +77,9 @@ public class CKanbanColumn extends CEntityNamed<CKanbanColumn> implements IOrder
 			return;
 		}
 		this.kanbanLine = kanbanLine;
+	}
+
+	public void setStatuses(final List<CProjectItemStatus> statuses) {
+		this.statuses = statuses != null ? statuses : new ArrayList<>();
 	}
 }

--- a/src/main/java/tech/derbent/app/kanban/kanbanline/view/CDialogKanbanColumnEdit.java
+++ b/src/main/java/tech/derbent/app/kanban/kanbanline/view/CDialogKanbanColumnEdit.java
@@ -27,7 +27,7 @@ public class CDialogKanbanColumnEdit extends CDialogDBEdit<CKanbanColumn> {
 
 	private void createFormFields() throws Exception {
 		Check.notNull(getDialogLayout(), "Dialog layout must be initialized before building form fields");
-		getDialogLayout().add(formBuilder.build(CKanbanColumn.class, binder, List.of("name", "description", "itemOrder", "active")));
+		getDialogLayout().add(formBuilder.build(CKanbanColumn.class, binder, List.of("name", "description", "statuses", "itemOrder", "active")));
 	}
 
 	@Override


### PR DESCRIPTION
### Motivation
- Kanban columns should be able to include a company-defined set of workflow/status entities so cards can be mapped to column-specific statuses. 
- Reuse existing selection UI patterns (grid-selection / `CComponentListSelection`) and backend status services to provide a consistent editing experience. 
- Persist the selection on the `CKanbanColumn` entity so column → statuses relationships survive restarts and can be queried. 

### Description
- Added a `List<CProjectItemStatus> statuses` many-to-many relation to `CKanbanColumn` with a join table `ckanbancolumn_statuses` and an `@AMetaData` annotation that sets `dataProviderBean = "CProjectItemStatusService"` and `useGridSelection = true`. 
- Exposed the new `statuses` field in the Kanban column edit dialog by adding `statuses` to the form fields list in `CDialogKanbanColumnEdit`. 
- Implemented getter and setter for the `statuses` list and added necessary imports (`CProjectItemStatus`, `List`, `ArrayList`, `@JoinTable`, `@ManyToMany`). 

### Testing
- No automated tests were run for this change. 
- Change is limited to domain and form metadata and should be picked up by existing form/component creation logic (`CFormBuilder`) which will render the grid-selection component for the field based on the provided `@AMetaData` settings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69470995a4148320a6dd718f4e2caa35)