### PR TITLE
Enforce unique kanban column names and reload newly saved column before constraints

### DIFF
--- a/src/main/java/tech/derbent/app/kanban/kanbanline/service/IKanbanColumnRepository.java
+++ b/src/main/java/tech/derbent/app/kanban/kanbanline/service/IKanbanColumnRepository.java
@@ -25,6 +25,10 @@ public interface IKanbanColumnRepository extends IAbstractRepository<CKanbanColu
 	@Query ("SELECT COALESCE(MAX(e.itemOrder), 0) + 1 FROM #{#entityName} e WHERE e.kanbanLine = :master")
 	Integer getNextItemOrder(@Param ("master") CKanbanLine master);
 
+	@Query ("SELECT DISTINCT e FROM #{#entityName} e LEFT JOIN FETCH e.kanbanLine LEFT JOIN FETCH e.includedStatuses "
+			+ "WHERE e.kanbanLine = :master AND LOWER(e.name) = LOWER(:name)")
+	Optional<CKanbanColumn> findByMasterAndNameIgnoreCase(@Param ("master") CKanbanLine master, @Param ("name") String name);
+
 	@Query ("SELECT DISTINCT e FROM #{#entityName} e LEFT JOIN FETCH e.kanbanLine LEFT JOIN FETCH e.includedStatuses WHERE e.id = :id")
 	Optional<CKanbanColumn> findByIdWithLine(@Param ("id") Long id);
 }


### PR DESCRIPTION
### Motivation
- Fix a race/identity issue during kanban column `save` where the in-memory `entity` still referenced an unsaved object and lacked a persisted `id` when `applyStatusAndDefaultConstraints` ran.
- Prevent duplicate column names within the same `CKanbanLine` so users cannot save columns with conflicting names.
- Ensure constraint logic operates on a persisted entity so `id` checks and joins are reliable.
- Verify deletion semantics remain cascade-friendly via the existing `CKanbanLine` orphanRemoval pattern (no repository-level delete was introduced).

### Description
- Added a repository lookup `findByMasterAndNameIgnoreCase` to `IKanbanColumnRepository` to support case-insensitive name lookups by line.
- In `CKanbanColumnService.save` added `Check.notBlank(entity.getName())` and a `validateUniqueName` call to enforce per-line uniqueness before save.
- For new columns the code now saves the parent line, then reloads the persisted column via `reloadByName(line, entity.getName())` and calls `applyStatusAndDefaultConstraints` on the reloaded entity so `id` is available.
- Implemented `reloadByName` and `validateUniqueName` helpers and wired them into the existing save flow without changing delete behaviour.

### Testing
- Ran `./run-playwright-tests.sh all` which failed immediately due to an unknown script option `all` (script usage differs from invoked option).
- Ran `PLAYWRIGHT_HEADLESS=true ./run-playwright-tests.sh menu` which attempted to run the menu UI test but failed because no Chromium browser was available in the environment, causing the Playwright-based UI test to fail with a null `page` and a single failing test.
- No unit tests were added or modified for this change and the build reported test failures due to the Playwright UI environment rather than the new service logic.
- Manual inspection and static checks confirm the repository and service changes implement the intended uniqueness and reload behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948cefdab68832096ef1b3e0dba2b02)