### PR TITLE
Fix workflow relation binding and status handling

### DIFF
--- a/src/main/java/tech/derbent/api/entityOfCompany/service/CProjectItemStatusService.java
+++ b/src/main/java/tech/derbent/api/entityOfCompany/service/CProjectItemStatusService.java
@@ -4,9 +4,11 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tech.derbent.api.entityOfCompany.domain.CProjectItemStatus;
@@ -68,26 +70,34 @@ public class CProjectItemStatusService extends CStatusService<CProjectItemStatus
 	 * is defined in the workflow's status relations where CWorkflowStatusRelation.initialStatus = true.
 	 * @param workflow the workflow entity to get initial status from
 	 * @return Optional containing the initial status if found, empty otherwise */
-	public Optional<CProjectItemStatus> getInitialStatusFromWorkflow(final CWorkflowEntity workflow) {
-		Check.notNull(workflow, "Workflow cannot be null when retrieving initial status");
-		try {
-			final List<CWorkflowStatusRelation> relations = workflowStatusRelationService.findByWorkflow(workflow);
-			Check.notEmpty(relations, "No status relations found for workflow: " + workflow.getName());
-			final Optional<CProjectItemStatus> initialStatus = relations.stream().filter(r -> r.getInitialStatus() != null && r.getInitialStatus())
-					.map(CWorkflowStatusRelation::getToStatus).distinct().findFirst();
-			if (initialStatus.isPresent()) {
-				return initialStatus;
-			}
-			if (!relations.isEmpty()) {
-				final CProjectItemStatus fallbackStatus = relations.get(0).getFromStatus();
-				return Optional.of(fallbackStatus);
-			}
-			LOGGER.warn("No status relations found for workflow: {}", workflow.getName());
-		} catch (final Exception e) {
-			LOGGER.error("Error retrieving initial status for workflow {}: {}", workflow.getName(), e.getMessage());
-		}
-		return Optional.empty();
-	}
+        public Optional<CProjectItemStatus> getInitialStatusFromWorkflow(final CWorkflowEntity workflow) {
+                Check.notNull(workflow, "Workflow cannot be null when retrieving initial status");
+                try {
+                        final List<CWorkflowStatusRelation> relations = workflowStatusRelationService.findByWorkflow(workflow);
+                        if (relations == null || relations.isEmpty()) {
+                                LOGGER.warn("No status relations found for workflow: {}", workflow.getName());
+                                return Optional.empty();
+                        }
+                        final Optional<CProjectItemStatus> initialStatus = relations.stream()
+                                        .filter(r -> Boolean.TRUE.equals(r.getInitialStatus())).map(CWorkflowStatusRelation::getToStatus).filter(Objects::nonNull).distinct()
+                                        .findFirst();
+                        if (initialStatus.isPresent()) {
+                                return initialStatus;
+                        }
+                        for (final CWorkflowStatusRelation relation : relations) {
+                                if (relation.getFromStatus() != null) {
+                                        return Optional.of(relation.getFromStatus());
+                                }
+                        }
+                        final CWorkflowStatusRelation firstRelation = relations.get(0);
+                        if (firstRelation.getToStatus() != null) {
+                                return Optional.of(firstRelation.getToStatus());
+                        }
+                } catch (final Exception e) {
+                        LOGGER.error("Error retrieving initial status for workflow {}: {}", workflow.getName(), e.getMessage());
+                }
+                return Optional.empty();
+        }
 
 	@Override
 	public Class<?> getPageServiceClass() { return CPageServiceProjectItemStatus.class; }
@@ -104,33 +114,66 @@ public class CProjectItemStatusService extends CStatusService<CProjectItemStatus
 	 * </ul>
 	 * @param item the project item entity
 	 * @return list of valid next statuses */
-	public List<CProjectItemStatus> getValidNextStatuses(final IHasStatusAndWorkflow<?> item) {
-		try {
-			Check.notNull(item, "Project item cannot be null when retrieving valid next statuses");
-			final List<CProjectItemStatus> validStatuses = new ArrayList<>();
-			final CWorkflowEntity workflow = item.getWorkflow();
-			Check.notNull(workflow, "Workflow cannot be null for project item");
-			final CProjectItemStatus currentStatus = item.getStatus();
-			if (currentStatus != null) {
-				validStatuses.add(item.getStatus()); // Always include current status
-			} else {
-				// For new items without a status, return initial statuses from the workflow
-				// LOGGER.debug("Getting initial statuses for new project item with workflow: {}", workflow.getName());
-				final Optional<CProjectItemStatus> initialStatus = getInitialStatusFromWorkflow(workflow);
-				initialStatus.ifPresent(validStatuses::add);
-				return validStatuses;
-			}
-			// Get workflow relations to find valid next statuses
-			final List<CWorkflowStatusRelation> relations = workflowStatusRelationService.findByWorkflow(workflow);
-			// Find relations where fromStatus matches current status and exclude current status from valid next statuses
-			relations.stream().filter(r -> r.getFromStatus().getId().equals(currentStatus.getId())).map(CWorkflowStatusRelation::getToStatus)
-					.distinct().filter(r -> !r.getId().equals(currentStatus.getId())).forEach(validStatuses::add);
-			return validStatuses;
-		} catch (final Exception e) {
-			LOGGER.error("Error retrieving valid next statuses for project item {}: {}", item.toString(), e.getMessage());
-			throw e;
-		}
-	}
+        public List<CProjectItemStatus> getValidNextStatuses(final IHasStatusAndWorkflow<?> item) {
+                try {
+                        Check.notNull(item, "Project item cannot be null when retrieving valid next statuses");
+                        final List<CProjectItemStatus> validStatuses = new ArrayList<>();
+                        final CWorkflowEntity workflow = item.getWorkflow();
+                        final CProjectItemStatus currentStatus = item.getStatus();
+                        if (currentStatus != null && !validStatuses.contains(currentStatus)) {
+                                validStatuses.add(item.getStatus()); // Always include current status
+                        }
+                        if (workflow == null) {
+                                LOGGER.warn("Workflow cannot be null for project item {}; returning default statuses", item.getClass().getSimpleName());
+                                addFallbackStatuses(validStatuses);
+                                return validStatuses;
+                        }
+                        // For new items without a status, return initial statuses from the workflow
+                        if (currentStatus == null) {
+                                final Optional<CProjectItemStatus> initialStatus = getInitialStatusFromWorkflow(workflow);
+                                if (initialStatus.isPresent()) {
+                                        addIfAbsent(validStatuses, initialStatus.get());
+                                        return validStatuses;
+                                }
+                        }
+                        final List<CWorkflowStatusRelation> relations = workflowStatusRelationService.findByWorkflow(workflow);
+                        if (relations == null || relations.isEmpty()) {
+                                addFallbackStatuses(validStatuses);
+                                return validStatuses;
+                        }
+                        if (currentStatus != null && currentStatus.getId() != null) {
+                                relations.stream().filter(r -> r.getFromStatus().getId().equals(currentStatus.getId())).map(CWorkflowStatusRelation::getToStatus)
+                                                .filter(Objects::nonNull).distinct().filter(r -> !r.getId().equals(currentStatus.getId()))
+                                                .forEach(status -> addIfAbsent(validStatuses, status));
+                        }
+                        if (validStatuses.isEmpty()) {
+                                addFallbackStatuses(validStatuses);
+                        }
+                        return validStatuses;
+                } catch (final Exception e) {
+                        LOGGER.error("Error retrieving valid next statuses for project item {}: {}", item.toString(), e.getMessage());
+                        throw e;
+                }
+        }
+
+        private void addFallbackStatuses(final List<CProjectItemStatus> validStatuses) {
+                list(Pageable.unpaged()).getContent().forEach(status -> addIfAbsent(validStatuses, status));
+        }
+
+        private void addIfAbsent(final List<CProjectItemStatus> statuses, final CProjectItemStatus statusToAdd) {
+                if (statusToAdd == null) {
+                        return;
+                }
+                final boolean alreadyPresent = statuses.stream().anyMatch(status -> {
+                        if (status.getId() != null && statusToAdd.getId() != null) {
+                                return status.getId().equals(statusToAdd.getId());
+                        }
+                        return status.equals(statusToAdd);
+                });
+                if (!alreadyPresent) {
+                        statuses.add(statusToAdd);
+                }
+        }
 
 	/** Initializes a new activity status with default values. Most common fields are initialized by super class.
 	 * @param entity the newly created activity status to initialize */

--- a/src/main/java/tech/derbent/app/workflow/domain/CWorkflowEntity.java
+++ b/src/main/java/tech/derbent/app/workflow/domain/CWorkflowEntity.java
@@ -38,7 +38,7 @@ public class CWorkflowEntity extends CWorkflowBase<CWorkflowEntity> {
 	)
 	private Boolean isActive = Boolean.TRUE;
 	// lets keep it layzily loaded to avoid loading all status relations at once
-	@OneToMany (mappedBy = "workflowentity", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+        @OneToMany (mappedBy = "workflowEntity", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
 	@AMetaData (
 			displayName = "Status Transitions", required = false, readOnly = false, description = "Status transitions for this workflow",
 			hidden = false, dataProviderBean = "CWorkflowEntityService", createComponentMethod = "createWorkflowStatusRelationsComponent",

--- a/src/main/java/tech/derbent/app/workflow/domain/CWorkflowStatusRelation.java
+++ b/src/main/java/tech/derbent/app/workflow/domain/CWorkflowStatusRelation.java
@@ -68,7 +68,7 @@ public class CWorkflowStatusRelation extends CEntityDB<CWorkflowStatusRelation> 
 			displayName = "Workflow", required = true, readOnly = false, description = "The workflow this status relation belongs to", hidden = false,
 			setBackgroundFromColor = true, useIcon = true, dataProviderBean = "CWorkflowEntityService"
 	)
-	private CWorkflowEntity workflowentity;
+        private CWorkflowEntity workflowEntity;
 
 	public CWorkflowStatusRelation() {
 		super(CWorkflowStatusRelation.class);
@@ -82,7 +82,7 @@ public class CWorkflowStatusRelation extends CEntityDB<CWorkflowStatusRelation> 
 
 	public CProjectItemStatus getToStatus() { return toStatus; }
 
-	public CWorkflowEntity getWorkflowEntity() { return workflowentity; }
+        public CWorkflowEntity getWorkflowEntity() { return workflowEntity; }
 
 	public void setFromStatus(final CProjectItemStatus fromStatus) { this.fromStatus = fromStatus; }
 
@@ -92,14 +92,14 @@ public class CWorkflowStatusRelation extends CEntityDB<CWorkflowStatusRelation> 
 
 	public void setToStatus(final CProjectItemStatus toStatus) { this.toStatus = toStatus; }
 
-	public void setWorkflowEntity(final CWorkflowEntity workflowentity) { this.workflowentity = workflowentity; }
+        public void setWorkflowEntity(final CWorkflowEntity workflowEntity) { this.workflowEntity = workflowEntity; }
 
 	@Override
 	public String toString() {
-		return String.format("WorkflowStatusRelation[workflow id=%s, from status id=%s, to status id=%s, roles=%s]",
-				workflowentity != null ? CSpringAuxillaries.safeGetId(workflowentity) : null,
-				fromStatus != null ? CSpringAuxillaries.safeGetId(fromStatus) : null,
-				toStatus != null ? CSpringAuxillaries.safeGetId(toStatus) : null,
+                                return String.format("WorkflowStatusRelation[workflow id=%s, from status id=%s, to status id=%s, roles=%s]",
+                                workflowEntity != null ? CSpringAuxillaries.safeGetId(workflowEntity) : null,
+                                fromStatus != null ? CSpringAuxillaries.safeGetId(fromStatus) : null,
+                                toStatus != null ? CSpringAuxillaries.safeGetId(toStatus) : null,
 				roles != null ? roles.stream().map(CSpringAuxillaries::safeToString).collect(java.util.stream.Collectors.joining(", ")) : "[]");
 	}
 }

--- a/src/main/java/tech/derbent/app/workflow/service/CWorkflowStatusRelationInitializerService.java
+++ b/src/main/java/tech/derbent/app/workflow/service/CWorkflowStatusRelationInitializerService.java
@@ -32,10 +32,11 @@ public final class CWorkflowStatusRelationInitializerService extends CInitialize
 			final CDetailSection detailSection = createBaseScreenEntity(project, ENTITY_CLASS);
 			detailSection.addScreenLine(CDetailLinesService.createSection(BASE_PANEL_NAME));
 			detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(ENTITY_CLASS, "id"));
-			detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(ENTITY_CLASS, "workflowentity"));
-			detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(ENTITY_CLASS, "fromStatus"));
-			detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(ENTITY_CLASS, "toStatus"));
-			detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(ENTITY_CLASS, "roles"));
+                        detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(ENTITY_CLASS, "workflowEntity"));
+                        detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(ENTITY_CLASS, "fromStatus"));
+                        detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(ENTITY_CLASS, "toStatus"));
+                        detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(ENTITY_CLASS, "initialStatus"));
+                        detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(ENTITY_CLASS, "roles"));
 			
 			detailSection.addScreenLine(CDetailLinesService.createSection("Status"));
 			detailSection.addScreenLine(CDetailLinesService.createLineFromDefaults(ENTITY_CLASS, "active"));
@@ -52,9 +53,9 @@ public final class CWorkflowStatusRelationInitializerService extends CInitialize
 
 	public static CGridEntity createGridEntity(final CProject project) {
 		final CGridEntity grid = createBaseGridEntity(project, ENTITY_CLASS);
-		grid.setColumnFields(List.of("id", "workflowentity", "fromStatus", "toStatus", "roles", "active"));
-		return grid;
-	}
+                grid.setColumnFields(List.of("id", "workflowEntity", "fromStatus", "toStatus", "initialStatus", "roles", "active"));
+                return grid;
+        }
 
 	public static void initialize(final CProject project, final CGridEntityService gridEntityService,
 			final CDetailSectionService detailSectionService, final CPageEntityService pageEntityService) throws Exception {

--- a/src/main/java/tech/derbent/app/workflow/service/CWorkflowStatusRelationService.java
+++ b/src/main/java/tech/derbent/app/workflow/service/CWorkflowStatusRelationService.java
@@ -34,25 +34,25 @@ public class CWorkflowStatusRelationService extends CAbstractEntityRelationServi
 
 	/** Add status transition to workflow with specific roles */
 	@Transactional
-	public CWorkflowStatusRelation addStatusTransition(final CWorkflowEntity workflowentity, final CProjectItemStatus fromStatus,
-			final CProjectItemStatus toStatus, final List<CUserProjectRole> roles) {
-		LOGGER.debug("Adding status transition to workflow {} from {} to {} for roles {}", workflowentity, fromStatus, toStatus, roles);
-		Check.notNull(workflowentity, "Workflow must not be null");
-		Check.notNull(fromStatus, "From status must not be null");
-		Check.notNull(toStatus, "To status must not be null");
-		if ((workflowentity.getId() == null) || (fromStatus.getId() == null) || (toStatus.getId() == null)) {
-			throw new IllegalArgumentException("Workflow and statuses must have valid IDs");
-		}
-		if (relationshipExists(workflowentity.getId(), fromStatus.getId(), toStatus.getId())) {
-			throw new IllegalArgumentException("This status transition is already defined for this workflow");
-		}
-		final CWorkflowStatusRelation relation = new CWorkflowStatusRelation();
-		relation.setWorkflowEntity(workflowentity);
-		relation.setFromStatus(fromStatus);
-		relation.setToStatus(toStatus);
-		relation.setRoles(roles);
-		validateRelationship(relation);
-		return save(relation);
+        public CWorkflowStatusRelation addStatusTransition(final CWorkflowEntity workflowEntity, final CProjectItemStatus fromStatus,
+                        final CProjectItemStatus toStatus, final List<CUserProjectRole> roles) {
+                LOGGER.debug("Adding status transition to workflow {} from {} to {} for roles {}", workflowEntity, fromStatus, toStatus, roles);
+                Check.notNull(workflowEntity, "Workflow must not be null");
+                Check.notNull(fromStatus, "From status must not be null");
+                Check.notNull(toStatus, "To status must not be null");
+                if ((workflowEntity.getId() == null) || (fromStatus.getId() == null) || (toStatus.getId() == null)) {
+                        throw new IllegalArgumentException("Workflow and statuses must have valid IDs");
+                }
+                if (relationshipExists(workflowEntity.getId(), fromStatus.getId(), toStatus.getId())) {
+                        throw new IllegalArgumentException("This status transition is already defined for this workflow");
+                }
+                final CWorkflowStatusRelation relation = new CWorkflowStatusRelation();
+                relation.setWorkflowEntity(workflowEntity);
+                relation.setFromStatus(fromStatus);
+                relation.setToStatus(toStatus);
+                relation.setRoles(roles);
+                validateRelationship(relation);
+                return save(relation);
 	}
 
 	@Override

--- a/src/main/java/tech/derbent/app/workflow/service/IHasStatusAndWorkflowService.java
+++ b/src/main/java/tech/derbent/app/workflow/service/IHasStatusAndWorkflowService.java
@@ -15,15 +15,14 @@ public interface IHasStatusAndWorkflowService<EntityClass extends CProjectItem<E
 
 	Logger LOGGER = LoggerFactory.getLogger(IHasStatusAndWorkflowService.class);
 
-	static CProjectItemStatus getInitialStatus(final IHasStatusAndWorkflow<?> entity, final CProjectItemStatusService projectItemStatusService) {
-		LOGGER.debug("Retrieving initial status for entity of type: {}", entity.getClass().getSimpleName());
-		Check.notNull(projectItemStatusService, "projectItemStatusService cannot be null");
-		Check.notNull(entity, "entity cannot be null");
-		Check.notNull(entity.getWorkflow(), "entity.workflow cannot be null");
-		final List<CProjectItemStatus> initialStatuses = projectItemStatusService.getValidNextStatuses(entity);
-		Check.notEmpty(initialStatuses, "No statuses returned from getValidNextStatuses for entity type " + entity.getClass().getSimpleName());
-		return initialStatuses.get(0);
-	}
+        static CProjectItemStatus getInitialStatus(final IHasStatusAndWorkflow<?> entity, final CProjectItemStatusService projectItemStatusService) {
+                LOGGER.debug("Retrieving initial status for entity of type: {}", entity.getClass().getSimpleName());
+                Check.notNull(projectItemStatusService, "projectItemStatusService cannot be null");
+                Check.notNull(entity, "entity cannot be null");
+                final List<CProjectItemStatus> initialStatuses = projectItemStatusService.getValidNextStatuses(entity);
+                Check.notEmpty(initialStatuses, "No statuses returned from getValidNextStatuses for entity type " + entity.getClass().getSimpleName());
+                return initialStatuses.get(0);
+        }
 
 	static void initializeNewEntity(final IHasStatusAndWorkflow<?> entity, final CProject currentProject, final CTypeEntityService<?> typeService,
 			final CProjectItemStatusService projectItemStatusService) {

--- a/src/main/java/tech/derbent/app/workflow/service/IWorkflowStatusRelationRepository.java
+++ b/src/main/java/tech/derbent/app/workflow/service/IWorkflowStatusRelationRepository.java
@@ -15,51 +15,51 @@ import tech.derbent.app.workflow.domain.CWorkflowStatusRelation;
 public interface IWorkflowStatusRelationRepository extends IAbstractRepository<CWorkflowStatusRelation> {
 
 	/** Count relations for a specific workflow using generic pattern */
-	@Query ("SELECT COUNT(r) FROM #{#entityName} r WHERE r.workflowentity.id = :workflowId")
-	long countByWorkflowId(@Param ("workflowId") Long workflowId);
+        @Query ("SELECT COUNT(r) FROM #{#entityName} r WHERE r.workflowEntity.id = :workflowId")
+        long countByWorkflowId(@Param ("workflowId") Long workflowId);
 	/** Delete all workflow-status relationships for a specific workflow using generic pattern */
 	@Modifying
 	@Transactional
-	@Query ("DELETE FROM #{#entityName} r WHERE r.workflowentity.id = :workflowId")
-	void deleteByWorkflowId(@Param ("workflowId") Long workflowId);
+        @Query ("DELETE FROM #{#entityName} r WHERE r.workflowEntity.id = :workflowId")
+        void deleteByWorkflowId(@Param ("workflowId") Long workflowId);
 	/** Delete a specific workflow-status relationship by workflow, from status, and to status IDs using generic pattern */
 	@Modifying
 	@Transactional
 	@Query (
-		"DELETE FROM #{#entityName} r WHERE r.workflowentity.id = :workflowId AND r.fromStatus.id = :fromStatusId AND r.toStatus.id = :toStatusId"
-	)
+                "DELETE FROM #{#entityName} r WHERE r.workflowEntity.id = :workflowId AND r.fromStatus.id = :fromStatusId AND r.toStatus.id = :toStatusId"
+        )
 	void deleteByWorkflowIdAndFromStatusIdAndToStatusId(@Param ("workflowId") Long workflowId, @Param ("fromStatusId") Long fromStatusId,
 			@Param ("toStatusId") Long toStatusId);
 	/** Check if a relationship exists between workflow and statuses */
 	@Query (
-		"SELECT COUNT(r) > 0 FROM #{#entityName} r WHERE r.workflowentity.id = :workflowId AND r.fromStatus.id = :fromStatusId AND r.toStatus.id = :toStatusId"
-	)
+                "SELECT COUNT(r) > 0 FROM #{#entityName} r WHERE r.workflowEntity.id = :workflowId AND r.fromStatus.id = :fromStatusId AND r.toStatus.id = :toStatusId"
+        )
 	boolean existsByWorkflowIdAndFromStatusIdAndToStatusId(@Param ("workflowId") Long workflowId, @Param ("fromStatusId") Long fromStatusId,
 			@Param ("toStatusId") Long toStatusId);
 	/** Find all workflow status relations for a specific status (as from status) with eager loading */
 	@Query (
-		"SELECT DISTINCT r FROM #{#entityName} r LEFT JOIN FETCH r.workflowentity LEFT JOIN FETCH r.fromStatus LEFT JOIN FETCH r.toStatus LEFT JOIN FETCH r.roles WHERE r.fromStatus.id = :statusId"
-	)
+                "SELECT DISTINCT r FROM #{#entityName} r LEFT JOIN FETCH r.workflowEntity LEFT JOIN FETCH r.fromStatus LEFT JOIN FETCH r.toStatus LEFT JOIN FETCH r.roles WHERE r.fromStatus.id = :statusId"
+        )
 	List<CWorkflowStatusRelation> findByFromStatusId(@Param ("statusId") Long statusId);
 	/** Find all relations that include a specific role using generic pattern */
 	@Query (
-		"SELECT DISTINCT r FROM #{#entityName} r LEFT JOIN FETCH r.workflowentity LEFT JOIN FETCH r.fromStatus LEFT JOIN FETCH r.toStatus LEFT JOIN FETCH r.roles role WHERE role.id = :roleId"
-	)
+                "SELECT DISTINCT r FROM #{#entityName} r LEFT JOIN FETCH r.workflowEntity LEFT JOIN FETCH r.fromStatus LEFT JOIN FETCH r.toStatus LEFT JOIN FETCH r.roles role WHERE role.id = :roleId"
+        )
 	List<CWorkflowStatusRelation> findByRoleId(@Param ("roleId") Long roleId);
 	/** Find all workflow status relations for a specific status (as to status) with eager loading */
 	@Query (
-		"SELECT DISTINCT r FROM #{#entityName} r LEFT JOIN FETCH r.workflowentity LEFT JOIN FETCH r.fromStatus LEFT JOIN FETCH r.toStatus LEFT JOIN FETCH r.roles WHERE r.toStatus.id = :statusId"
-	)
+                "SELECT DISTINCT r FROM #{#entityName} r LEFT JOIN FETCH r.workflowEntity LEFT JOIN FETCH r.fromStatus LEFT JOIN FETCH r.toStatus LEFT JOIN FETCH r.roles WHERE r.toStatus.id = :statusId"
+        )
 	List<CWorkflowStatusRelation> findByToStatusId(@Param ("statusId") Long statusId);
 	/** Find all workflow status relations for a specific workflow with eager loading of workflow, statuses, and roles. */
 	@Query (
-		"SELECT DISTINCT r FROM #{#entityName} r LEFT JOIN FETCH r.workflowentity LEFT JOIN FETCH r.fromStatus LEFT JOIN FETCH r.toStatus LEFT JOIN FETCH r.roles WHERE r.workflowentity.id = :workflowId"
-	)
+                "SELECT DISTINCT r FROM #{#entityName} r LEFT JOIN FETCH r.workflowEntity LEFT JOIN FETCH r.fromStatus LEFT JOIN FETCH r.toStatus LEFT JOIN FETCH r.roles WHERE r.workflowEntity.id = :workflowId"
+        )
 	List<CWorkflowStatusRelation> findByWorkflowId(@Param ("workflowId") Long workflowId);
 	/** Find a specific workflow status relation by workflow, from status, and to status */
 	@Query (
-		"SELECT DISTINCT r FROM #{#entityName} r LEFT JOIN FETCH r.workflowentity LEFT JOIN FETCH r.fromStatus LEFT JOIN FETCH r.toStatus LEFT JOIN FETCH r.roles WHERE r.workflowentity.id = :workflowId AND r.fromStatus.id = :fromStatusId AND r.toStatus.id = :toStatusId"
-	)
-	Optional<CWorkflowStatusRelation> findByWorkflowIdAndFromStatusIdAndToStatusId(@Param ("workflowId") Long workflowId,
+                "SELECT DISTINCT r FROM #{#entityName} r LEFT JOIN FETCH r.workflowEntity LEFT JOIN FETCH r.fromStatus LEFT JOIN FETCH r.toStatus LEFT JOIN FETCH r.roles WHERE r.workflowEntity.id = :workflowId AND r.fromStatus.id = :fromStatusId AND r.toStatus.id = :toStatusId"
+        )
+        Optional<CWorkflowStatusRelation> findByWorkflowIdAndFromStatusIdAndToStatusId(@Param ("workflowId") Long workflowId,
 			@Param ("fromStatusId") Long fromStatusId, @Param ("toStatusId") Long toStatusId);
 }

--- a/src/main/java/tech/derbent/app/workflow/view/CComponentWorkflowStatusRelationBase.java
+++ b/src/main/java/tech/derbent/app/workflow/view/CComponentWorkflowStatusRelationBase.java
@@ -64,7 +64,7 @@ public abstract class CComponentWorkflowStatusRelationBase<MasterClass extends C
 		Check.notNull(relation, "Relation cannot be null when getting display text");
 		try {
 			switch (type) {
-			case "workflowentity":
+                        case "workflowEntity":
 				Check.notNull(relation.getWorkflowEntity(), "Workflow cannot be null");
 				return CColorUtils.getDisplayTextFromEntity(relation.getWorkflowEntity());
 			case "fromStatus":
@@ -130,7 +130,7 @@ public abstract class CComponentWorkflowStatusRelationBase<MasterClass extends C
 						return new CLabelEntity(relation.getWorkflowEntity());
 					} catch (@SuppressWarnings ("unused") final Exception e) {
 						LOGGER.error("Failed to create workflow component.");
-						return new com.vaadin.flow.component.html.Span(getDisplayText(relation, "workflowentity"));
+                                                return new com.vaadin.flow.component.html.Span(getDisplayText(relation, "workflowEntity"));
 					}
 				}).setAutoWidth(true).setSortable(true), "Workflow");
 			}


### PR DESCRIPTION
## Summary
- rename the workflow status relation association to `workflowEntity` and align repositories, views, and initializer bindings
- expose the `initialStatus` flag in the workflow status relation screen configuration
- harden project item status workflow logic with fallbacks when workflows or transitions are missing

## Testing
- ./run-playwright-tests.sh menu *(fails: Playwright browser not available in environment, CMenuNavigationTest null page)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69501b532d108320975cdafd94d6e99a)