### PR TITLE
Add sample initializer flows for company data

### DIFF
--- a/src/main/java/tech/derbent/api/config/CDataInitializer.java
+++ b/src/main/java/tech/derbent/api/config/CDataInitializer.java
@@ -1,7 +1,5 @@
 package tech.derbent.api.config;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.List;
 import org.slf4j.Logger;
@@ -162,10 +160,9 @@ public class CDataInitializer {
 	private static final String COMPANY_OF_TEKNOLOJI = "Of Teknoloji Çözümleri";
 	private static final Logger LOGGER = LoggerFactory.getLogger(CDataInitializer.class);
 	// Standard password for all users as per coding guidelines
-	private static final String STANDARD_PASSWORD = "test123";
-	// User Login Names
-	private static final String USER_ADMIN = "admin";
-	private static final String USER_ADMIN2 = "yasin";
+        // User Login Names
+        private static final String USER_ADMIN = "admin";
+        private static final String USER_ADMIN2 = "yasin";
 	private final CActivityPriorityService activityPriorityService;
 	private final CActivityService activityService;
 	private final CProjectItemStatusService activityStatusService;
@@ -339,40 +336,6 @@ public class CDataInitializer {
 		}
 	}
 
-	/** Creates consulting company. */
-	private void createConsultingCompany() {
-		final CCompany consulting = new CCompany(COMPANY_OF_DANISMANLIK);
-		consulting.setDescription("Yönetim danışmanlığı ve stratejik planlama hizmetleri");
-		consulting.setAddress("Merkez Mahallesi, Gülbahar Sokağı No:7, Of/Trabzon");
-		consulting.setPhone("+90-462-751-0303");
-		consulting.setEmail("merhaba@ofdanismanlik.com.tr");
-		consulting.setWebsite("https://www.ofdanismanlik.com.tr");
-		consulting.setTaxNumber("TR-456789123");
-		consulting.setCompanyTheme("lumo-light");
-		consulting.setCompanyLogoUrl("/assets/logos/consulting-logo.svg");
-		consulting.setPrimaryColor("#4caf50");
-		consulting.setWorkingHoursStart("08:30");
-		consulting.setWorkingHoursEnd("17:30");
-		consulting.setCompanyTimezone("Europe/Istanbul");
-		consulting.setDefaultLanguage("tr");
-		consulting.setEnableNotifications(true);
-		consulting.setNotificationEmail("bildirim@ofdanismanlik.com.tr");
-		companyService.save(consulting);
-	}
-
-	private void createProjectDigitalTransformation(final CCompany company) {
-		final CProject project = new CProject("Digital Transformation Initiative", company);
-		project.setDescription("Comprehensive digital transformation for enhanced customer experience");
-		project.setActive(true);
-		projectService.save(project);
-	}
-
-	private void createProjectInfrastructureUpgrade(final CCompany company) {
-		final CProject project = new CProject("Infrastructure Upgrade Project", company);
-		project.setDescription("Upgrading IT infrastructure for improved performance and scalability");
-		projectService.save(project);
-	}
-
 	/** Create sample comments for a decision.
 	 * @param decision the decision to create comments for */
 	private void createSampleCommentsForDecision(final CDecision decision) {
@@ -446,59 +409,6 @@ public class CDataInitializer {
 		} catch (final Exception e) {
 			LOGGER.error("Error creating comments for meeting: {}", meeting.getName(), e);
 		}
-	}
-
-	/** Creates a single user for a company with specified username and details.
-	 * @param company            The company to create user for
-	 * @param username           The username for the user
-	 * @param firstname          The first name for the user
-	 * @param phone              The phone number for the user
-	 * @param profilePictureFile The filename of the profile picture (e.g., "admin.svg") */
-	@Transactional (readOnly = false)
-	private void createSingleUserForCompany(final CCompany company, final String username, final String firstname, final String phone,
-			final String profilePictureFile) {
-		final String companyShortName = company.getName().toLowerCase().replaceAll("[^a-z0-9]", "");
-		final String userEmail = username + "@" + companyShortName + ".com.tr";
-		final CUserCompanyRole companyRole = userCompanyRoleService.getRandom(company);
-		final CUser user = userService.createLoginUser(username, STANDARD_PASSWORD, firstname, userEmail, company, companyRole);
-		// Set user profile directly on entity
-		final byte[] profilePictureBytes = loadProfilePictureData(profilePictureFile);
-		user.setLastname(company.getName() + " Yöneticisi");
-		user.setPhone(phone);
-		user.setProfilePictureData(profilePictureBytes);
-		user.setAttributeDisplaySectionsAsTabs(true);
-		userService.save(user);
-		// LOGGER.info("Created user {} for company {} with profile picture {}", username, company.getName(), profilePictureFile);
-	}
-
-	/** Creates technology startup company. */
-	private void createTechCompany() {
-		final CCompany techStartup = new CCompany(COMPANY_OF_TEKNOLOJI);
-		techStartup.setDescription("Dijital dönüşüm için yenilikçi teknoloji çözümleri");
-		techStartup.setAddress("Cumhuriyet Mahallesi, Atatürk Caddesi No:15, Of/Trabzon");
-		techStartup.setPhone("+90-462-751-0101");
-		techStartup.setEmail("iletisim@ofteknoloji.com.tr");
-		techStartup.setWebsite("https://www.ofteknoloji.com.tr");
-		techStartup.setTaxNumber("TR-123456789");
-		techStartup.setCompanyTheme("lumo-dark");
-		techStartup.setCompanyLogoUrl("/assets/logos/tech-logo.svg");
-		techStartup.setPrimaryColor("#1976d2");
-		techStartup.setWorkingHoursStart("09:00");
-		techStartup.setWorkingHoursEnd("18:00");
-		techStartup.setCompanyTimezone("Europe/Istanbul");
-		techStartup.setDefaultLanguage("tr");
-		techStartup.setEnableNotifications(true);
-		techStartup.setNotificationEmail("bildirim@ofteknoloji.com.tr");
-		companyService.save(techStartup);
-	}
-
-	@Transactional (readOnly = false)
-	private void createUserForCompany(final CCompany company) {
-		// Create first admin user
-		createSingleUserForCompany(company, USER_ADMIN, "Admin", "+90-462-751-1001", "admin.svg");
-		// Create second admin user
-		createSingleUserForCompany(company, USER_ADMIN2, USER_ADMIN2, "+90-462-751-1002", "admin.svg");
-		LOGGER.info("Created 2 admin users for company {}", company.getName());
 	}
 
 	/** Initialize sample activities with parent-child relationships for hierarchy demonstration.
@@ -913,48 +823,20 @@ public class CDataInitializer {
 		return cnt == 0;
 	}
 
-	/** Loads profile picture data from the profile-pictures directory.
-	 * @param filename The SVG filename to load
-	 * @return byte array of the SVG content, or null if not found */
-	private byte[] loadProfilePictureData(final String filename) {
-		try {
-			// Try direct file path first (since profile-pictures is in project root)
-			final Path filePath = java.nio.file.Paths.get("profile-pictures", filename);
-			Check.isTrue(!filename.contains(".."), "Invalid filename: " + filename); // Prevent path traversal
-			if (Files.exists(filePath)) {
-				return Files.readAllBytes(filePath);
-			}
-			// Fallback: Load from classpath resources
-			final var resource = getClass().getClassLoader().getResourceAsStream("profile-pictures/" + filename);
-			Check.notNull(resource, "Profile picture resource not found in classpath: " + filename);
-			return resource.readAllBytes();
-		} catch (final Exception e) {
-			LOGGER.error("Error loading profile picture: {}", filename, e);
-			return null;
-		}
-	}
-
-	public void loadSampleData(final boolean minimal) throws Exception {
-		try {
-			// ========== NON-PROJECT RELATED INITIALIZATION PHASE ==========
-			// **** CREATE COMPANY SAMPLES ****//
-			createTechCompany();
-			if (!minimal) {
-				createConsultingCompany();
-			}
-			/* create sample projects */
-			for (final CCompany company : companyService.list(Pageable.unpaged()).getContent()) {
-				initializeSampleCompanyRoles(company, minimal);
-				createProjectDigitalTransformation(company);
-				if (!minimal) {
-					createProjectInfrastructureUpgrade(company);
-				}
-				createUserForCompany(company);
-				if (minimal) {
-					break;
-				}
-				// createUserFor(company);
-			}
+        public void loadSampleData(final boolean minimal) throws Exception {
+                try {
+                        // ========== NON-PROJECT RELATED INITIALIZATION PHASE ==========
+                        // **** CREATE COMPANY SAMPLES ****//
+                        CCompanyInitializerService.initializeSample(minimal);
+                        /* create sample projects */
+                        for (final CCompany company : companyService.list(Pageable.unpaged()).getContent()) {
+                                CUserCompanyRoleInitializerService.initializeSample(company, minimal);
+                                CUserInitializerService.initializeSample(company, minimal);
+                                CProjectInitializerService.initializeSample(company, minimal);
+                                if (minimal) {
+                                        break;
+                                }
+                        }
 			// ========== PROJECT-SPECIFIC INITIALIZATION PHASE ==========
 			for (final CCompany company : companyService.list(Pageable.unpaged()).getContent()) {
 				// sessionService.setActiveCompany(company);

--- a/src/main/java/tech/derbent/api/entityOfCompany/domain/CEntityOfCompany.java
+++ b/src/main/java/tech/derbent/api/entityOfCompany/domain/CEntityOfCompany.java
@@ -3,6 +3,8 @@ package tech.derbent.api.entityOfCompany.domain;
 import java.util.Arrays;
 import java.util.Collection;
 import org.jspecify.annotations.Nullable;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -14,13 +16,14 @@ import tech.derbent.app.companies.domain.CCompany;
 @MappedSuperclass
 public abstract class CEntityOfCompany<EntityClass> extends CEntityNamed<EntityClass> {
 
-	@ManyToOne (fetch = FetchType.LAZY)
-	@JoinColumn (name = "company_id", nullable = true)
-	@AMetaData (
-			displayName = "Company", required = false, readOnly = false, description = "User's company", hidden = false,
-			setBackgroundFromColor = true, useIcon = true
-	)
-	private CCompany company;
+        @ManyToOne (fetch = FetchType.LAZY)
+        @JoinColumn (name = "company_id", nullable = true)
+        @OnDelete (action = OnDeleteAction.CASCADE)
+        @AMetaData (
+                        displayName = "Company", required = false, readOnly = false, description = "User's company", hidden = false,
+                        setBackgroundFromColor = true, useIcon = true
+        )
+        private CCompany company;
 
 	/** Default constructor for JPA. */
 	protected CEntityOfCompany() {

--- a/src/main/java/tech/derbent/api/entityOfProject/domain/CEntityOfProject.java
+++ b/src/main/java/tech/derbent/api/entityOfProject/domain/CEntityOfProject.java
@@ -11,6 +11,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.MappedSuperclass;
 import tech.derbent.api.annotations.AMetaData;
 import tech.derbent.api.entity.domain.CEntityNamed;
+import tech.derbent.api.utils.Check;
 import tech.derbent.app.projects.domain.CProject;
 import tech.derbent.base.users.domain.CUser;
 
@@ -92,18 +93,40 @@ public abstract class CEntityOfProject<EntityClass> extends CEntityNamed<EntityC
 		return false;
 	}
 
-	/** Sets the assigned user for this entity.
-	 * @param assignedTo the user to assign */
-	public void setAssignedTo(final CUser assignedTo) {
-		// Check.isSameCompany(getProject(), assignedTo);
-		this.assignedTo = assignedTo;
-	}
+        /** Sets the assigned user for this entity.
+         * @param assignedTo the user to assign */
+        public void setAssignedTo(final CUser assignedTo) {
+                if (assignedTo == null) {
+                        this.assignedTo = null;
+                        return;
+                }
+                Check.notNull(project, "Project must be set before assigning a user");
+                Check.isSameCompany(project, assignedTo);
+                this.assignedTo = assignedTo;
+        }
 
-	/** Sets the user who created this entity.
-	 * @param createdBy the creator user */
-	public void setCreatedBy(final CUser createdBy) { this.createdBy = createdBy; }
+        /** Sets the user who created this entity.
+         * @param createdBy the creator user */
+        public void setCreatedBy(final CUser createdBy) {
+                if (createdBy == null) {
+                        this.createdBy = null;
+                        return;
+                }
+                Check.notNull(project, "Project must be set before setting creator");
+                Check.isSameCompany(project, createdBy);
+                this.createdBy = createdBy;
+        }
 
-	/** Sets the project this entity belongs to.
-	 * @param project the project to set */
-	public void setProject(final CProject project) { this.project = project; }
+        /** Sets the project this entity belongs to.
+         * @param project the project to set */
+        public void setProject(final CProject project) {
+                Check.notNull(project, "Project cannot be null for project-scoped entities");
+                if (assignedTo != null) {
+                        Check.isSameCompany(project, assignedTo);
+                }
+                if (createdBy != null) {
+                        Check.isSameCompany(project, createdBy);
+                }
+                this.project = project;
+        }
 }

--- a/src/main/java/tech/derbent/api/entityOfProject/domain/CProjectItem.java
+++ b/src/main/java/tech/derbent/api/entityOfProject/domain/CProjectItem.java
@@ -128,11 +128,11 @@ public abstract class CProjectItem<EntityClass> extends CEntityOfProject<EntityC
 
 	public void setParentType(final String parentType) { this.parentType = parentType; }
 
-	public void setStatus(final CProjectItemStatus status) {
-		Check.notNull(status, "Status cannot be null");
-		Check.isTrue(status.getCompany().getId().equals(getProject().getCompany().getId()),
-				"Status company id " + status.getCompany().getId() + " does not match item company id " + getProject().getCompany().getId());
-		this.status = status;
-		updateLastModified();
-	}
+        public void setStatus(final CProjectItemStatus status) {
+                Check.notNull(status, "Status cannot be null");
+                Check.notNull(getProject(), "Project must be set before applying status");
+                Check.isSameCompany(getProject(), status);
+                this.status = status;
+                updateLastModified();
+        }
 }

--- a/src/main/java/tech/derbent/app/companies/service/CCompanyInitializerService.java
+++ b/src/main/java/tech/derbent/app/companies/service/CCompanyInitializerService.java
@@ -3,6 +3,7 @@ package tech.derbent.app.companies.service;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tech.derbent.api.config.CSpringContext;
 import tech.derbent.api.screens.domain.CDetailSection;
 import tech.derbent.api.screens.domain.CGridEntity;
 import tech.derbent.api.screens.service.CDetailLinesService;
@@ -12,16 +13,21 @@ import tech.derbent.api.screens.service.CInitializerServiceBase;
 import tech.derbent.api.screens.service.CInitializerServiceNamedEntity;
 import tech.derbent.app.companies.domain.CCompany;
 import tech.derbent.app.page.service.CPageEntityService;
+import tech.derbent.app.companies.service.CCompanyService;
 import tech.derbent.app.projects.domain.CProject;
 
 public class CCompanyInitializerService extends CInitializerServiceBase {
-	static final Class<?> clazz = CCompany.class;
-	private static final Logger LOGGER = LoggerFactory.getLogger(CCompanyInitializerService.class);
-	private static final String menuOrder = Menu_Order_SYSTEM + ".1";
-	private static final String menuTitle = MenuTitle_SYSTEM + ".Companies";
-	private static final String pageDescription = "Company management with contact details";
-	private static final String pageTitle = "Company Management";
-	private static final boolean showInQuickToolbar = false;
+        static final Class<?> clazz = CCompany.class;
+        private static final Logger LOGGER = LoggerFactory.getLogger(CCompanyInitializerService.class);
+        private static final String menuOrder = Menu_Order_SYSTEM + ".1";
+        private static final String menuTitle = MenuTitle_SYSTEM + ".Companies";
+        private static final String pageDescription = "Company management with contact details";
+        private static final String pageTitle = "Company Management";
+        private static final boolean showInQuickToolbar = false;
+        private record CompanySeed(String name, String description, String address, String phone, String email, String website,
+                        String taxNumber, String theme, String logoUrl, String primaryColor, String workingHoursStart,
+                        String workingHoursEnd, String timezone, String language, boolean notificationsEnabled,
+                        String notificationEmail) {}
 
 	public static CDetailSection createBasicView(final CProject project) throws Exception {
 		try {
@@ -74,9 +80,49 @@ public class CCompanyInitializerService extends CInitializerServiceBase {
 		grid = createGridEntity(project);
 		detailSection = createBasicView(project);
 		detailSection.setName("Current Company Detail Section");
-		grid.setName("Current Company Grid");
-		grid.setAttributeNone(true);
-		initBase(clazz, project, gridEntityService, detailSectionService, pageEntityService, detailSection, grid, "System.Current Company", pageTitle,
-				pageDescription, showInQuickToolbar, menuOrder);
-	}
+                grid.setName("Current Company Grid");
+                grid.setAttributeNone(true);
+                initBase(clazz, project, gridEntityService, detailSectionService, pageEntityService, detailSection, grid, "System.Current Company", pageTitle,
+                                pageDescription, showInQuickToolbar, menuOrder);
+        }
+
+        public static void initializeSample(final boolean minimal) throws Exception {
+                final CCompanyService companyService = CSpringContext.getBean(CCompanyService.class);
+                final List<CompanySeed> seeds = List.of(
+                                new CompanySeed("Of Teknoloji Çözümleri",
+                                                "Dijital dönüşüm için yenilikçi teknoloji çözümleri",
+                                                "Cumhuriyet Mahallesi, Atatürk Caddesi No:15, Of/Trabzon", "+90-462-751-0101",
+                                                "iletisim@ofteknoloji.com.tr", "https://www.ofteknoloji.com.tr", "TR-123456789",
+                                                "lumo-dark", "/assets/logos/tech-logo.svg", "#1976d2", "09:00", "18:00",
+                                                "Europe/Istanbul", "tr", true, "bildirim@ofteknoloji.com.tr"),
+                                new CompanySeed("Of Stratejik Danışmanlık",
+                                                "Yönetim danışmanlığı ve stratejik planlama hizmetleri",
+                                                "Merkez Mahallesi, Gülbahar Sokağı No:7, Of/Trabzon", "+90-462-751-0303",
+                                                "merhaba@ofdanismanlik.com.tr", "https://www.ofdanismanlik.com.tr", "TR-456789123",
+                                                "lumo-light", "/assets/logos/consulting-logo.svg", "#4caf50", "08:30", "17:30",
+                                                "Europe/Istanbul", "tr", true, "bildirim@ofdanismanlik.com.tr"));
+                for (final CompanySeed seed : seeds) {
+                        final CCompany company = new CCompany(seed.name());
+                        company.setDescription(seed.description());
+                        company.setAddress(seed.address());
+                        company.setPhone(seed.phone());
+                        company.setEmail(seed.email());
+                        company.setWebsite(seed.website());
+                        company.setTaxNumber(seed.taxNumber());
+                        company.setCompanyTheme(seed.theme());
+                        company.setCompanyLogoUrl(seed.logoUrl());
+                        company.setPrimaryColor(seed.primaryColor());
+                        company.setWorkingHoursStart(seed.workingHoursStart());
+                        company.setWorkingHoursEnd(seed.workingHoursEnd());
+                        company.setCompanyTimezone(seed.timezone());
+                        company.setDefaultLanguage(seed.language());
+                        company.setEnableNotifications(seed.notificationsEnabled());
+                        company.setNotificationEmail(seed.notificationEmail());
+                        company.setActive(true);
+                        companyService.save(company);
+                        if (minimal) {
+                                break;
+                        }
+                }
+        }
 }

--- a/src/main/java/tech/derbent/app/projects/service/CProjectInitializerService.java
+++ b/src/main/java/tech/derbent/app/projects/service/CProjectInitializerService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tech.derbent.api.entityOfCompany.service.CEntityOfCompanyService;
+import tech.derbent.api.registry.CEntityRegistry;
 import tech.derbent.api.screens.domain.CDetailLines;
 import tech.derbent.api.screens.domain.CDetailSection;
 import tech.derbent.api.screens.domain.CGridEntity;
@@ -11,9 +13,11 @@ import tech.derbent.api.screens.service.CDetailLinesService;
 import tech.derbent.api.screens.service.CDetailSectionService;
 import tech.derbent.api.screens.service.CEntityFieldService.EntityFieldInfo;
 import tech.derbent.api.screens.service.CGridEntityService;
+import tech.derbent.api.config.CSpringContext;
 import tech.derbent.api.screens.service.CInitializerServiceBase;
 import tech.derbent.api.screens.service.CInitializerServiceNamedEntity;
 import tech.derbent.app.page.service.CPageEntityService;
+import tech.derbent.app.companies.domain.CCompany;
 import tech.derbent.app.projects.domain.CProject;
 
 public class CProjectInitializerService extends CInitializerServiceBase {
@@ -60,11 +64,24 @@ public class CProjectInitializerService extends CInitializerServiceBase {
                 return grid;
         }
 
-	public static void initialize(final CProject project, final CGridEntityService gridEntityService,
-			final CDetailSectionService detailSectionService, final CPageEntityService pageEntityService) throws Exception {
-		final CDetailSection detailSection = createBasicView(project);
-		final CGridEntity grid = createGridEntity(project);
-		initBase(clazz, project, gridEntityService, detailSectionService, pageEntityService, detailSection, grid, menuTitle, pageTitle,
-				pageDescription, showInQuickToolbar, menuOrder);
-	}
+        public static void initialize(final CProject project, final CGridEntityService gridEntityService,
+                        final CDetailSectionService detailSectionService, final CPageEntityService pageEntityService) throws Exception {
+                final CDetailSection detailSection = createBasicView(project);
+                final CGridEntity grid = createGridEntity(project);
+                initBase(clazz, project, gridEntityService, detailSectionService, pageEntityService, detailSection, grid, menuTitle, pageTitle,
+                                pageDescription, showInQuickToolbar, menuOrder);
+        }
+
+        public static void initializeSample(final CCompany company, final boolean minimal) throws Exception {
+                final String[][] nameAndDescription = {
+                                {
+                                                "Digital Transformation Initiative", "Comprehensive digital transformation for enhanced customer experience"
+                                }, {
+                                                "Infrastructure Upgrade Project", "Upgrading IT infrastructure for improved performance and scalability"
+                                }
+                };
+                initializeCompanyEntity(nameAndDescription,
+                                (CEntityOfCompanyService<?>) CSpringContext.getBean(CEntityRegistry.getServiceClassForEntity(clazz)), company,
+                                minimal, (item, index) -> ((CProject) item).setActive(true));
+        }
 }

--- a/src/main/java/tech/derbent/app/projects/service/IProjectRepository.java
+++ b/src/main/java/tech/derbent/app/projects/service/IProjectRepository.java
@@ -5,11 +5,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import tech.derbent.api.entity.service.IAbstractNamedRepository;
+import tech.derbent.api.entityOfCompany.service.IEntityOfCompanyRepository;
 import tech.derbent.app.companies.service.ICompanyEntityRepositoryBase;
 import tech.derbent.app.projects.domain.CProject;
 
-public interface IProjectRepository extends IAbstractNamedRepository<CProject>, ICompanyEntityRepositoryBase<CProject> {
+public interface IProjectRepository extends IEntityOfCompanyRepository<CProject>, ICompanyEntityRepositoryBase<CProject> {
 
 	@Override
 	@Query ("SELECT p FROM CProject p LEFT JOIN FETCH company WHERE p.company.id = :company_id ORDER BY p.name")

--- a/src/main/java/tech/derbent/app/roles/service/CUserCompanyRoleInitializerService.java
+++ b/src/main/java/tech/derbent/app/roles/service/CUserCompanyRoleInitializerService.java
@@ -10,6 +10,9 @@ import tech.derbent.api.screens.service.CDetailSectionService;
 import tech.derbent.api.screens.service.CGridEntityService;
 import tech.derbent.api.screens.service.CInitializerServiceBase;
 import tech.derbent.api.screens.service.CInitializerServiceNamedEntity;
+import tech.derbent.api.config.CSpringContext;
+import tech.derbent.api.utils.CColorUtils;
+import tech.derbent.app.companies.domain.CCompany;
 import tech.derbent.app.page.service.CPageEntityService;
 import tech.derbent.app.projects.domain.CProject;
 import tech.derbent.app.roles.domain.CUserCompanyRole;
@@ -51,11 +54,40 @@ public class CUserCompanyRoleInitializerService extends CInitializerServiceBase 
 		return grid;
 	}
 
-	public static void initialize(final CProject project, final CGridEntityService gridEntityService,
-			final CDetailSectionService detailSectionService, final CPageEntityService pageEntityService) throws Exception {
-		final CDetailSection detailSection = createBasicView(project);
-		final CGridEntity grid = createGridEntity(project);
-		initBase(clazz, project, gridEntityService, detailSectionService, pageEntityService, detailSection, grid, menuTitle, pageTitle,
-				pageDescription, showInQuickToolbar, menuOrder);
-	}
+        public static void initialize(final CProject project, final CGridEntityService gridEntityService,
+                        final CDetailSectionService detailSectionService, final CPageEntityService pageEntityService) throws Exception {
+                final CDetailSection detailSection = createBasicView(project);
+                final CGridEntity grid = createGridEntity(project);
+                initBase(clazz, project, gridEntityService, detailSectionService, pageEntityService, detailSection, grid, menuTitle, pageTitle,
+                                pageDescription, showInQuickToolbar, menuOrder);
+        }
+
+        public static void initializeSample(final CCompany company, final boolean minimal) throws Exception {
+                final CUserCompanyRoleService service = CSpringContext.getBean(CUserCompanyRoleService.class);
+                final String[][] nameAndDescription = {
+                                {
+                                                "Company Admin", "Administrative role with full company access"
+                                }, {
+                                                "Company User", "Standard user role with regular access"
+                                }, {
+                                                "Company Guest", "Guest role with limited access"
+                                }
+                };
+                int index = 0;
+                for (final String[] seed : nameAndDescription) {
+                        final CUserCompanyRole role = service.newEntity(seed[0]);
+                        role.setDescription(seed[1]);
+                        role.setCompany(company);
+                        role.setColor(CColorUtils.getRandomColor(true));
+                        role.setSortOrder(index + 1);
+                        role.setIsAdmin(index == 0);
+                        role.setIsUser(index == 1);
+                        role.setIsGuest(index == 2);
+                        service.save(role);
+                        index++;
+                        if (minimal) {
+                                return;
+                        }
+                }
+        }
 }

--- a/src/main/java/tech/derbent/base/users/domain/CUserProjectSettings.java
+++ b/src/main/java/tech/derbent/base/users/domain/CUserProjectSettings.java
@@ -11,6 +11,7 @@ import jakarta.persistence.UniqueConstraint;
 import tech.derbent.api.annotations.AMetaData;
 import tech.derbent.api.annotations.CSpringAuxillaries;
 import tech.derbent.api.entity.domain.CEntityDB;
+import tech.derbent.api.utils.Check;
 import tech.derbent.app.projects.domain.CProject;
 import tech.derbent.app.roles.domain.CUserProjectRole;
 
@@ -67,11 +68,33 @@ public class CUserProjectSettings extends CEntityDB<CUserProjectSettings> {
 
 	public void setPermission(final String permission) { this.permission = permission; }
 
-	public void setProject(final CProject project) { this.project = project; }
+        public void setProject(final CProject project) {
+                Check.notNull(project, "Project cannot be null for user project settings");
+                if (user != null) { Check.isSameCompany(project, user); }
+                if (role != null && role.getProject() != null) {
+                        Check.isTrue(role.getProject().getId().equals(project.getId()), "Project role is linked to a different project");
+                }
+                this.project = project;
+        }
 
-	public void setRole(final CUserProjectRole role) { this.role = role; }
+        public void setRole(final CUserProjectRole role) {
+                if (role == null) {
+                        this.role = null;
+                        return;
+                }
+                Check.notNull(project, "Project must be set before assigning a role");
+                if (role.getProject() != null) {
+                        Check.isTrue(role.getProject().getId().equals(project.getId()), "Role must belong to the same project");
+                }
+                this.role = role;
+        }
 
-	public void setUser(final CUser user) { this.user = user; }
+        public void setUser(final CUser user) {
+                Check.notNull(user, "User cannot be null for project settings");
+                Check.notNull(project, "Project must be set before assigning a user");
+                Check.isSameCompany(project, user);
+                this.user = user;
+        }
 
 	@Override
 	public String toString() {


### PR DESCRIPTION
## Summary
- add sample company, user, and project seed creation helpers through initializer services
- wire data initializer to use the new initializer flows while keeping project save guards company-scoped
- tighten user project settings validation to fail fast on cross-company/project assignments

## Testing
- ./mvnw -DskipTests compile
- ./run-playwright-tests.sh menu (fails: Playwright browser not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695101a6fb5c83209096a164e1de6edf)