### PR TITLE
Inline dynamic onepager helper and seed initializers

### DIFF
--- a/src/main/java/tech/derbent/api/config/CDataInitializer.java
+++ b/src/main/java/tech/derbent/api/config/CDataInitializer.java
@@ -17,6 +17,7 @@ import tech.derbent.api.screens.service.CDetailLinesService;
 import tech.derbent.api.screens.service.CDetailSectionService;
 import tech.derbent.api.screens.service.CGridEntityInitializerService;
 import tech.derbent.api.screens.service.CGridEntityService;
+import tech.derbent.api.screens.service.CMasterInitializerService;
 import tech.derbent.api.utils.Check;
 import tech.derbent.app.activities.domain.CActivity;
 import tech.derbent.app.activities.domain.CActivityPriority;
@@ -879,14 +880,17 @@ public class CDataInitializer {
 					CWorkflowEntityInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
 					COrderApprovalInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
 					CGanntViewEntityInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
-					CGridEntityInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
-					CPageEntityInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
-					CSprintTypeInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
-					CSprintInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
-					/******************* SAMPLES **************************/
-					// Project-specific type and configuration entities
-					CCurrencyInitializerService.initializeSample(project, minimal);
-					CUserProjectRoleInitializerService.initializeSample(project, minimal);
+                                        CGridEntityInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
+                                        CPageEntityInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
+                                        CSprintTypeInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
+                                        CSprintInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
+                                        /******************* SAMPLES **************************/
+                                        // Project-specific type and configuration entities
+                                        CSystemSettingsInitializerService.initializeSample(project, minimal);
+                                        CGridEntityInitializerService.initializeSample(project, minimal);
+                                        CMasterInitializerService.initializeSample(project, minimal);
+                                        CCurrencyInitializerService.initializeSample(project, minimal);
+                                        CUserProjectRoleInitializerService.initializeSample(project, minimal);
 					// types
 					initializeSampleWorkflowEntities(project, minimal);
 					CMeetingTypeInitializerService.initializeSample(project, minimal);
@@ -919,14 +923,15 @@ public class CDataInitializer {
 					CMilestoneInitializerService.initializeSample(project, minimal);
 					initializeSampleTickets(project, minimal);
 					CProviderInitializerService.initializeSample(project, minimal);
-					CProductInitializerService.initializeSample(project, minimal);
-					CProjectComponentInitializerService.initializeSample(project, minimal);
-					initializeSampleProjectExpenses(project, minimal);
-					initializeSampleProjectIncomes(project, minimal);
-					initializeSampleTeams(project, minimal);
-					CRiskInitializerService.initializeSample(project, minimal);
-					CSprintInitializerService.initializeSample(project, minimal);
-					CKanbanLineInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
+                                        CProductInitializerService.initializeSample(project, minimal);
+                                        CProjectComponentInitializerService.initializeSample(project, minimal);
+                                        initializeSampleProjectExpenses(project, minimal);
+                                        initializeSampleProjectIncomes(project, minimal);
+                                        COrderApprovalInitializerService.initializeSample(project, minimal);
+                                        initializeSampleTeams(project, minimal);
+                                        CRiskInitializerService.initializeSample(project, minimal);
+                                        CSprintInitializerService.initializeSample(project, minimal);
+                                        CKanbanLineInitializerService.initialize(project, gridEntityService, screenService, pageEntityService);
 					if (minimal) {
 						break;
 					}

--- a/src/main/java/tech/derbent/api/screens/service/CGridEntityInitializerService.java
+++ b/src/main/java/tech/derbent/api/screens/service/CGridEntityInitializerService.java
@@ -1,5 +1,6 @@
 package tech.derbent.api.screens.service;
 
+import tech.derbent.api.config.CSpringContext;
 import tech.derbent.api.utils.Check;
 
 import java.util.List;
@@ -7,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tech.derbent.api.screens.domain.CDetailSection;
 import tech.derbent.api.screens.domain.CGridEntity;
+import tech.derbent.api.screens.service.CGridEntityService;
 import tech.derbent.app.page.service.CPageEntityService;
 import tech.derbent.app.projects.domain.CProject;
 
@@ -53,11 +55,28 @@ public class CGridEntityInitializerService extends CInitializerServiceBase {
 		return createGridEntity(project);
 	}
 
-	public static void initialize(final CProject project, final CGridEntityService gridEntityService,
-			final CDetailSectionService detailSectionService, final CPageEntityService pageEntityService) throws Exception {
-		final CDetailSection detailSection = createBasicView(project);
-		final CGridEntity grid = createGridEntity(project);
-		initBase(clazz, project, gridEntityService, detailSectionService, pageEntityService, detailSection, grid, menuTitle, pageTitle,
-				pageDescription, showInQuickToolbar, menuOrder);
-	}
+        public static void initialize(final CProject project, final CGridEntityService gridEntityService,
+                        final CDetailSectionService detailSectionService, final CPageEntityService pageEntityService) throws Exception {
+                final CDetailSection detailSection = createBasicView(project);
+                final CGridEntity grid = createGridEntity(project);
+                initBase(clazz, project, gridEntityService, detailSectionService, pageEntityService, detailSection, grid, menuTitle, pageTitle,
+                                pageDescription, showInQuickToolbar, menuOrder);
+        }
+
+        public static void initializeSample(final CProject project, final boolean minimal) throws Exception {
+                Check.notNull(project, "project cannot be null");
+                final String[][] sampleGrids = {
+                                {"Project Grid Registry", "Catalog of grid definitions available in the project"},
+                                {"Read-Only Grid Template", "Baseline grid template with non-deletable flag"}
+                };
+                final CGridEntityService gridService = CSpringContext.getBean(CGridEntityService.class);
+                initializeProjectEntity(sampleGrids, gridService, project, minimal, (gridEntity, index) -> {
+                        gridEntity.setDataServiceBeanName(CGridEntityService.class.getSimpleName());
+                        gridEntity.setAttributeNonDeletable(true);
+                        gridEntity.setColumnFields(List.of("name", "description", "dataServiceBeanName", "project", "attributeNonDeletable"));
+                        if (index == 1) {
+                                gridEntity.setAttributeNone(true);
+                        }
+                });
+        }
 }

--- a/src/main/java/tech/derbent/api/screens/service/CMasterInitializerService.java
+++ b/src/main/java/tech/derbent/api/screens/service/CMasterInitializerService.java
@@ -1,5 +1,6 @@
 package tech.derbent.api.screens.service;
 
+import tech.derbent.api.config.CSpringContext;
 import tech.derbent.api.utils.Check;
 
 import java.util.List;
@@ -8,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import tech.derbent.api.screens.domain.CDetailSection;
 import tech.derbent.api.screens.domain.CGridEntity;
 import tech.derbent.api.screens.domain.CMasterSection;
+import tech.derbent.api.screens.service.CMasterSectionService;
 import tech.derbent.app.page.service.CPageEntityService;
 import tech.derbent.app.projects.domain.CProject;
 
@@ -48,11 +50,26 @@ public class CMasterInitializerService extends CInitializerServiceBase {
 		return grid;
 	}
 
-	public static void initialize(final CProject project, final CGridEntityService gridEntityService,
-			final CDetailSectionService detailSectionService, final CPageEntityService pageEntityService) throws Exception {
-		final CDetailSection detailSection = createBasicView(project);
-		final CGridEntity grid = createGridEntity(project);
-		initBase(clazz, project, gridEntityService, detailSectionService, pageEntityService, detailSection, grid, menuTitle, pageTitle,
-				pageDescription, showInQuickToolbar, menuOrder);
-	}
+        public static void initialize(final CProject project, final CGridEntityService gridEntityService,
+                        final CDetailSectionService detailSectionService, final CPageEntityService pageEntityService) throws Exception {
+                final CDetailSection detailSection = createBasicView(project);
+                final CGridEntity grid = createGridEntity(project);
+                initBase(clazz, project, gridEntityService, detailSectionService, pageEntityService, detailSection, grid, menuTitle, pageTitle,
+                                pageDescription, showInQuickToolbar, menuOrder);
+        }
+
+        public static void initializeSample(final CProject project, final boolean minimal) throws Exception {
+                Check.notNull(project, "project cannot be null");
+                final String[][] sections = {
+                                {"General Master Section", "Reusable section template for project pages"},
+                                {"Timeline Master Section", "Timeline-focused master layout"}
+                };
+                final CMasterSectionService masterSectionService = CSpringContext.getBean(CMasterSectionService.class);
+                initializeProjectEntity(sections, masterSectionService, project, minimal, (section, index) -> {
+                        final List<String> availableTypes = CMasterSectionService.getAvailableTypes();
+                        final String defaultType = availableTypes.isEmpty() ? "None" : availableTypes.get(Math.min(index, availableTypes.size() - 1));
+                        section.setSectionType(defaultType);
+                        section.setSectionDBName((section.getName() + "_" + project.getId()).toLowerCase().replaceAll("[^a-z0-9]+", "_"));
+                });
+        }
 }

--- a/src/main/java/tech/derbent/app/gannt/ganntviewentity/view/CGridViewBaseGannt.java
+++ b/src/main/java/tech/derbent/app/gannt/ganntviewentity/view/CGridViewBaseGannt.java
@@ -1,6 +1,5 @@
 package tech.derbent.app.gannt.ganntviewentity.view;
 
-import java.lang.reflect.Field;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,8 +18,8 @@ import tech.derbent.app.activities.service.CActivityService;
 import tech.derbent.app.gannt.ganntitem.domain.CGanntItem;
 import tech.derbent.app.gannt.ganntviewentity.view.components.CGanntGrid;
 import tech.derbent.app.meetings.service.CMeetingService;
-import tech.derbent.app.page.domain.CPageEntity;
 import tech.derbent.app.page.service.CPageEntityService;
+import tech.derbent.app.page.view.CDynamicPageRouter;
 import tech.derbent.app.page.view.CDynamicPageRouter;
 import tech.derbent.base.session.service.ISessionService;
 
@@ -67,28 +66,9 @@ public abstract class CGridViewBaseGannt<EntityClass extends CEntityOfProject<En
 				new CMasterViewSectionGannt<EntityClass>(entityClass, this, sessionService, activityService, meetingService, pageEntityService);
 	}
 
-	private void displayEntityInDynamicOnepager(CProjectItem<?> onepagerEntity) {
-		try {
-			LOGGER.debug("Locating Gantt entity in dynamic page: {}", onepagerEntity != null ? onepagerEntity.getName() : "null");
-			if (onepagerEntity == null) {
-				currentEntityPageRouter.loadSpecificPage(null, null, true);
-				return;
-			}
-			final CPageEntityService pageService = CSpringContext.getBean(CPageEntityService.class);
-			final Field viewNameField = onepagerEntity.getClass().getField("VIEW_NAME");
-			final String entityViewName = (String) viewNameField.get(null);
-			final CPageEntity page = pageService.findByNameAndProject(entityViewName, sessionService.getActiveProject().orElse(null)).orElseThrow();
-			Check.notNull(page, "Screen service cannot be null");
-			//
-			currentEntityPageRouter.loadSpecificPage(page.getId(), onepagerEntity.getId(), true);
-		} catch (final Exception e) {
-			CNotificationService.showException("Error creating dynamic page for entity", e);
-		}
-	}
-
-	/** Gets the entity binder for the actual entity (Activity or Meeting). This is needed for the page service to write binder data before saving.
-	 * @return The entity binder */
-	public CEnhancedBinder<CProjectItem<?>> getEntityBinder() { return entityBinder; }
+        /** Gets the entity binder for the actual entity (Activity or Meeting). This is needed for the page service to write binder data before saving.
+         * @return The entity binder */
+        public CEnhancedBinder<CProjectItem<?>> getEntityBinder() { return entityBinder; }
 
 	private CProjectItem<?> getGanntEntityFromSelectedItem() {
 		LOGGER.debug("Getting Gantt entity from selected CGanttItem");
@@ -216,9 +196,9 @@ public abstract class CGridViewBaseGannt<EntityClass extends CEntityOfProject<En
 		}
 	}
 
-	@Override
-	protected void updateDetailsComponent() throws Exception {
-		LOGGER.debug("Updating details component for Gantt view");
-		displayEntityInDynamicOnepager(getGanntEntityFromSelectedItem());
-	}
+        @Override
+        protected void updateDetailsComponent() throws Exception {
+                LOGGER.debug("Updating details component for Gantt view");
+                CDynamicPageRouter.displayEntityInDynamicOnepager(getGanntEntityFromSelectedItem(), currentEntityPageRouter, sessionService);
+        }
 }

--- a/src/main/java/tech/derbent/base/setup/service/CSystemSettingsInitializerService.java
+++ b/src/main/java/tech/derbent/base/setup/service/CSystemSettingsInitializerService.java
@@ -3,6 +3,7 @@ package tech.derbent.base.setup.service;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tech.derbent.api.config.CSpringContext;
 import tech.derbent.api.utils.Check;
 import tech.derbent.app.page.domain.CPageEntity;
 import tech.derbent.app.page.service.CPageEntityService;
@@ -14,6 +15,7 @@ import tech.derbent.api.screens.service.CDetailSectionService;
 import tech.derbent.api.screens.service.CGridEntityService;
 import tech.derbent.api.screens.service.CInitializerServiceBase;
 import tech.derbent.base.setup.domain.CSystemSettings;
+import tech.derbent.base.setup.service.CSystemSettingsService;
 
 /** CSystemSettingsInitializerService - Initializer service for CSystemSettings entities. This service creates the dynamic page configuration for
  * system-wide settings management, including grid and detail section definitions. Since system settings are global (not project-related), this
@@ -101,19 +103,31 @@ public class CSystemSettingsInitializerService extends CInitializerServiceBase {
 		return grid;
 	}
 
-	public static void initialize(final CProject project, final CGridEntityService gridEntityService,
-			final CDetailSectionService detailSectionService, final CPageEntityService pageEntityService) throws Exception {
-		Check.notNull(project, "project cannot be null");
-		final CDetailSection detailSection = createBasicView(project);
-		final CGridEntity grid = createGridEntity(project);
+        public static void initialize(final CProject project, final CGridEntityService gridEntityService,
+                        final CDetailSectionService detailSectionService, final CPageEntityService pageEntityService) throws Exception {
+                Check.notNull(project, "project cannot be null");
+                final CDetailSection detailSection = createBasicView(project);
+                final CGridEntity grid = createGridEntity(project);
 		initBase(clazz, project, gridEntityService, detailSectionService, pageEntityService, detailSection, grid, menuTitle, pageTitle,
 				pageDescription, showInQuickToolbar, menuOrder);
 		// Create a single system settings page (like company single view)
 		final CGridEntity singleGrid = createGridEntity(project, true);
-		singleGrid.setName("System Settings Single View");
-		gridEntityService.save(singleGrid);
-		final CPageEntity singlePage = createPageEntity(clazz, project, singleGrid, detailSection, "System.Current Settings", "System Settings",
-				"System-wide configuration settings", "1.1");
-		pageEntityService.save(singlePage);
-	}
+                singleGrid.setName("System Settings Single View");
+                gridEntityService.save(singleGrid);
+                final CPageEntity singlePage = createPageEntity(clazz, project, singleGrid, detailSection, "System.Current Settings", "System Settings",
+                                "System-wide configuration settings", "1.1");
+                pageEntityService.save(singlePage);
+        }
+
+        public static void initializeSample(final CProject project, final boolean minimal) throws Exception {
+                final CSystemSettingsService systemSettingsService = CSpringContext.getBean(CSystemSettingsService.class);
+                final CSystemSettings settings = systemSettingsService.getOrCreateSystemSettings();
+                if (settings.getApplicationName() == null || settings.getApplicationName().isBlank()) {
+                        settings.setApplicationName("Derbent Project Management");
+                }
+                if (settings.getApplicationVersion() == null || settings.getApplicationVersion().isBlank()) {
+                        settings.setApplicationVersion("1.0.0");
+                }
+                systemSettingsService.save(settings);
+        }
 }


### PR DESCRIPTION
## Summary
- Move dynamic one-pager display handling into `CDynamicPageRouter` and update Kanban/Gantt components to use it
- Add `initializeSample` implementations for grid, master section, system settings, and order approval initializer services
- Invoke the new sample initializers during data seeding for projects

## Testing
- `./run-playwright-tests.sh menu` *(fails: Playwright browser not available in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69516393202c8320bf6a77babe6b03d5)